### PR TITLE
analysisutil.IsObj: don't use obj.Id() as uniq identifier

### DIFF
--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -38,6 +38,10 @@ func TestTestifyLint(t *testing.T) {
 			},
 		},
 		{dir: "ginkgo"},
+		{
+			dir:   "not-std-funcs",
+			flags: map[string]string{"enable-all": "true"},
+		},
 		{dir: "not-test-file"},    // By default, linter checks regular files too.
 		{dir: "not-true-testify"}, // Linter ignores stretchr/testify's forks.
 		{dir: "pkg-alias"},

--- a/analyzer/testdata/src/not-std-funcs/errors/is.go
+++ b/analyzer/testdata/src/not-std-funcs/errors/is.go
@@ -1,0 +1,5 @@
+package errors
+
+func Is(err error, v int) bool {
+	return false
+}

--- a/analyzer/testdata/src/not-std-funcs/not_std_funcs_test.go
+++ b/analyzer/testdata/src/not-std-funcs/not_std_funcs_test.go
@@ -1,0 +1,40 @@
+package notstdfuncs
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	myerrors "not-std-funcs/errors"
+)
+
+func TestCustomStuff(t *testing.T) {
+	var err error
+	var errSentinel = errors.New("unexpected")
+	var scores []float64
+
+	assert.Equal(t, nil, scores) // want "nil-compare: use assert\\.Nil"
+
+	assert.True(t, myerrors.Is(err, 2))
+	assert.False(t, Is(err, errSentinel))
+	assert.True(t, As(err, &err))
+	assert.Equal(t, 3, len(scores))
+
+	require.True(t, myerrors.Is(err, 3))
+	require.False(t, Is(err, errSentinel))
+	require.True(t, As(err, &err))
+	require.Equal(t, 4, len(scores))
+}
+
+func Is(err, target error) bool {
+	return true
+}
+
+func As(err error, target any) bool {
+	return false
+}
+
+func len[T any](arr T) int {
+	return 3
+}

--- a/analyzer/testdata/src/not-std-funcs/not_std_funcs_test.go.golden
+++ b/analyzer/testdata/src/not-std-funcs/not_std_funcs_test.go.golden
@@ -1,0 +1,40 @@
+package notstdfuncs
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	myerrors "not-std-funcs/errors"
+)
+
+func TestCustomStuff(t *testing.T) {
+	var err error
+	var errSentinel = errors.New("unexpected")
+	var scores []float64
+
+	assert.Nil(t, scores) // want "nil-compare: use assert\\.Nil"
+
+	assert.True(t, myerrors.Is(err, 2))
+	assert.False(t, Is(err, errSentinel))
+	assert.True(t, As(err, &err))
+	assert.Equal(t, 3, len(scores))
+
+	require.True(t, myerrors.Is(err, 3))
+	require.False(t, Is(err, errSentinel))
+	require.True(t, As(err, &err))
+	require.Equal(t, 4, len(scores))
+}
+
+func Is(err, target error) bool {
+	return true
+}
+
+func As(err error, target any) bool {
+	return false
+}
+
+func len[T any](arr T) int {
+	return 3
+}

--- a/internal/analysisutil/object.go
+++ b/internal/analysisutil/object.go
@@ -30,5 +30,5 @@ func IsObj(typesInfo *types.Info, expr ast.Expr, expected types.Object) bool {
 	}
 
 	obj := typesInfo.ObjectOf(id)
-	return obj.Id() == expected.Id()
+	return obj == expected
 }

--- a/internal/analysisutil/object_test.go
+++ b/internal/analysisutil/object_test.go
@@ -114,3 +114,18 @@ func TestIsObj(t *testing.T) {
 		})
 	}
 }
+
+func TestIsObj_NamesakesFromDifferentPackages(t *testing.T) {
+	lhs := types.NewFunc(token.NoPos, types.NewPackage("errors", "errors"), "Is", nil)
+	rhs := types.NewFunc(token.NoPos, types.NewPackage("pkg/errors", "errors"), "Is", nil)
+
+	ident := new(ast.Ident)
+	typesInfo := &types.Info{
+		Defs: map[*ast.Ident]types.Object{
+			ident: lhs,
+		},
+	}
+	if analysisutil.IsObj(typesInfo, ident, rhs) {
+		t.Fatalf("objects should not be equal")
+	}
+}


### PR DESCRIPTION
Closes https://github.com/Antonboom/testifylint/issues/31