### PR TITLE
More examples in checkers documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ https://golangci-lint.run/usage/linters/#testifylint
      assert.True(t, a < b)
      assert.True(t, a <= b)
      assert.False(t, a == b)
-     // And other variations...
+     // And so on...
 
 ✅   assert.Equal(t, a, b)
      assert.NotEqual(t, a, b)
@@ -348,7 +348,7 @@ P.S. Related `testify`'s [thread](https://github.com/stretchr/testify/issues/772
 ### require-error
 
 ```go
-❌   assert.Error(t, err) // s.Error(err), s.Assert().Error(t, err)
+❌   assert.Error(t, err) // s.Error(err), s.Assert().Error(err)
      assert.ErrorIs(t, err, io.EOF)
      assert.ErrorAs(t, err, &target)
      assert.EqualError(t, err, "end of file")
@@ -356,10 +356,10 @@ P.S. Related `testify`'s [thread](https://github.com/stretchr/testify/issues/772
      assert.NoError(t, err)
      assert.NotErrorIs(t, err, io.EOF)
 
-✅   require.Error(t, err) // s.Require().Error(err), s.Require().Error(t, err)
+✅   require.Error(t, err) // s.Require().Error(err), s.Require().Error(err)
      require.ErrorIs(t, err, io.EOF)
      require.ErrorAs(t, err, &target)
-    // And so on...
+     // And so on...
 ```
 
 **Autofix**: false. <br>

--- a/README.md
+++ b/README.md
@@ -91,8 +91,11 @@ https://golangci-lint.run/usage/linters/#testifylint
 ### bool-compare
 
 ```go
-❌   assert.Equal(t, true, result)
+❌   assert.Equal(t, false, result)
+     assert.EqualValues(t, false, result)
+     assert.Exactly(t, false, result)
      assert.NotEqual(t, true, result)
+     assert.NotEqualValues(t, true, result) 
      assert.False(t, !result)
      assert.True(t, result == true)
      // And other variations...
@@ -116,7 +119,8 @@ https://golangci-lint.run/usage/linters/#testifylint
      assert.True(t, a >= b)
      assert.True(t, a < b)
      assert.True(t, a <= b)
-     // And other variations (with assert.False too)...
+     assert.False(t, a == b)
+     // And other variations...
 
 ✅   assert.Equal(t, a, b)
      assert.NotEqual(t, a, b)
@@ -137,9 +141,16 @@ https://golangci-lint.run/usage/linters/#testifylint
 ```go
 ❌   assert.Len(t, arr, 0)
      assert.Equal(t, 0, len(arr))
+     assert.EqualValues(t, 0, len(arr))
+     assert.Exactly(t, 0, len(arr))
+     assert.LessOrEqual(t, len(arr), 0)
+     assert.GreaterOrEqual(t, 0, len(arr))
+     assert.Less(t, len(arr), 1)
+     assert.Greater(t, 1, len(arr))
      assert.NotEqual(t, 0, len(arr))
-     assert.GreaterOrEqual(t, len(arr), 1)
-     // And other variations around len(arr)...
+     assert.NotEqualValues(t, 0, len(arr))
+     assert.Less(t, 0, len(arr))
+     assert.Greater(t, len(arr), 0)
 
 ✅   assert.Empty(t, arr)
      assert.NotEmpty(t, err)
@@ -180,9 +191,12 @@ logic, but without autofix.
 ```go
 ❌   assert.Nil(t, err)
      assert.NotNil(t, err)
-     assert.Equal(t, err, nil)
-     assert.NotEqual(t, err, nil)
+     assert.Equal(t, nil, err)
+     assert.EqualValues(t, nil, err)
+     assert.Exactly(t, nil, err)
      assert.ErrorIs(t, err, nil)
+     assert.NotEqual(t, nil, err)
+     assert.NotEqualValues(t, nil, err)
      assert.NotErrorIs(t, err, nil)
 
 ✅   assert.NoError(t, err)
@@ -198,15 +212,27 @@ logic, but without autofix.
 ### expected-actual
 
 ```go
-❌   assert.Equal(t, result, 42)
-     assert.NotEqual(t, result, "expected")
+❌   assert.Equal(t, result, expected)
+     assert.EqualExportedValues(t, resultObj, User{Name: "Rob"})
+     assert.EqualValues(t, result, 42)
+     assert.Exactly(t, result, int64(42))
      assert.JSONEq(t, result, `{"version": 3}`)
+     assert.InDelta(t, result, 42.42, 1.0)
+     assert.InDeltaMapValues(t, result, map[string]float64{"score": 0.99}, 1.0)
+     assert.InDeltaSlice(t, result, []float64{0.98, 0.99}, 1.0)
+     assert.InEpsilon(t, result, 42.42, 0.0001)
+     assert.IsType(t, result, (*User)(nil))
+     assert.NotEqual(t, result, "expected")
+     assert.NotEqualValues(t, result, "expected")
+     assert.NotSame(t, resultPtr, &value)
+     assert.Same(t, resultPtr, &value)
+     assert.WithinDuration(t, resultTime, time.Date(2023, 01, 12, 11, 46, 33, 0, nil), time.Second)
      assert.YAMLEq(t, result, "version: '3'")
 
-✅   assert.Equal(t, 42, result)
-     assert.NotEqual(t, "expected", result)
-     assert.JSONEq(t, `{"version": 3}`, result)
-     assert.YAMLEq(t, "version: '3'", result)
+✅   assert.Equal(t, expected, result)
+     assert.EqualExportedValues(t, User{Name: "Rob"}, resultObj)
+     assert.EqualValues(t, 42, result)
+    // And so on...
 ```
 
 **Autofix**: true. <br>
@@ -224,12 +250,13 @@ It is planned [to change the order of assertion arguments](https://github.com/st
 ### float-compare
 
 ```go
-❌   assert.Equal(t, 42.42, a)
-     assert.True(t, a == 42.42)
-     assert.False(t, a != 42.42)
+❌   assert.Equal(t, 42.42, result)
+     assert.EqualValues(t, 42.42, result)
+     assert.Exactly(t, 42.42, result)
+     assert.True(t, result == 42.42)
+     assert.False(t, result != 42.42)
 	
-✅   assert.InEpsilon(t, 42.42, a, 0.0001)
-     assert.InDelta(t, 42.42, a, 0.01)
+✅   assert.InEpsilon(t, 42.42, result, 0.0001) // Or assert.InDelta
 ```
 
 **Autofix**: false. <br>
@@ -286,6 +313,8 @@ P.S. Related `testify`'s [thread](https://github.com/stretchr/testify/issues/772
 
 ```go
 ❌   assert.Equal(t, 3, len(arr))
+     assert.EqualValues(t, 3, len(arr))
+     assert.Exactly(t, 3, len(arr))
      assert.True(t, len(arr) == 3)
 
 ✅   assert.Len(t, arr, 3)
@@ -300,8 +329,11 @@ P.S. Related `testify`'s [thread](https://github.com/stretchr/testify/issues/772
 ### nil-compare
 
 ```go
-❌   assert.Equal(t, value, nil)
-     assert.NotEqual(t, value, nil)
+❌   assert.Equal(t, nil, value)
+     assert.EqualValues(t, nil, value)
+     assert.Exactly(t, nil, value)
+     assert.NotEqual(t, nil, value)
+     assert.NotEqualValues(t, nil, value)
 
 ✅   assert.Nil(t, value)
      assert.NotNil(t, value)
@@ -316,14 +348,18 @@ P.S. Related `testify`'s [thread](https://github.com/stretchr/testify/issues/772
 ### require-error
 
 ```go
-❌   assert.NoError(t, err)
-     s.ErrorIs(err, io.EOF)
-     s.Assert().Error(err)
-     // And other error assertions...
+❌   assert.Error(t, err) // s.Error(err), s.Assert().Error(t, err)
+     assert.ErrorIs(t, err, io.EOF)
+     assert.ErrorAs(t, err, &target)
+     assert.EqualError(t, err, "end of file")
+     assert.ErrorContains(t, err, "end of file")
+     assert.NoError(t, err)
+     assert.NotErrorIs(t, err, io.EOF)
 
-✅   require.NoError(t, err)
-     s.Require().ErrorIs(err, io.EOF)
-     s.Require().Error(err)
+✅   require.Error(t, err) // s.Require().Error(err), s.Require().Error(t, err)
+     require.ErrorIs(t, err, io.EOF)
+     require.ErrorAs(t, err, &target)
+    // And so on...
 ```
 
 **Autofix**: false. <br>

--- a/analyzer/testdata/src/checkers-default/expected-actual/expected_actual_test.go
+++ b/analyzer/testdata/src/checkers-default/expected-actual/expected_actual_test.go
@@ -25,78 +25,89 @@ func TestExpectedActualChecker(t *testing.T) {
 	var expected string
 	var tt testCase
 	expectedVal := func() any { return nil }
+	var expectedObj struct{ Val int }
 
 	var result any
 
 	// Invalid.
 	{
-		assert.Equal(t, result, expected)                                                               // want "expected-actual: need to reverse actual and expected values"
-		assert.Equalf(t, result, expected, "msg with args %d %s", 42, "42")                             // want "expected-actual: need to reverse actual and expected values"
-		assert.Equal(t, result, tt.expected)                                                            // want "expected-actual: need to reverse actual and expected values"
-		assert.Equalf(t, result, tt.expected, "msg with args %d %s", 42, "42")                          // want "expected-actual: need to reverse actual and expected values"
-		assert.Equal(t, result, tt.exp())                                                               // want "expected-actual: need to reverse actual and expected values"
-		assert.Equalf(t, result, tt.exp(), "msg with args %d %s", 42, "42")                             // want "expected-actual: need to reverse actual and expected values"
-		assert.Equal(t, result, expectedVal())                                                          // want "expected-actual: need to reverse actual and expected values"
-		assert.Equalf(t, result, expectedVal(), "msg with args %d %s", 42, "42")                        // want "expected-actual: need to reverse actual and expected values"
-		assert.Equal(t, result, []int{1, 2, 3})                                                         // want "expected-actual: need to reverse actual and expected values"
-		assert.Equalf(t, result, []int{1, 2, 3}, "msg with args %d %s", 42, "42")                       // want "expected-actual: need to reverse actual and expected values"
-		assert.Equal(t, result, [3]int{1, 2, 3})                                                        // want "expected-actual: need to reverse actual and expected values"
-		assert.Equalf(t, result, [3]int{1, 2, 3}, "msg with args %d %s", 42, "42")                      // want "expected-actual: need to reverse actual and expected values"
-		assert.Equal(t, result, map[string]int{"0": 1})                                                 // want "expected-actual: need to reverse actual and expected values"
-		assert.Equalf(t, result, map[string]int{"0": 1}, "msg with args %d %s", 42, "42")               // want "expected-actual: need to reverse actual and expected values"
-		assert.Equal(t, result, user{Name: "Anton"})                                                    // want "expected-actual: need to reverse actual and expected values"
-		assert.Equalf(t, result, user{Name: "Anton"}, "msg with args %d %s", 42, "42")                  // want "expected-actual: need to reverse actual and expected values"
-		assert.Equal(t, result, struct{ Name string }{Name: "Anton"})                                   // want "expected-actual: need to reverse actual and expected values"
-		assert.Equalf(t, result, struct{ Name string }{Name: "Anton"}, "msg with args %d %s", 42, "42") // want "expected-actual: need to reverse actual and expected values"
-		assert.Equal(t, result, 42)                                                                     // want "expected-actual: need to reverse actual and expected values"
-		assert.Equalf(t, result, 42, "msg with args %d %s", 42, "42")                                   // want "expected-actual: need to reverse actual and expected values"
-		assert.Equal(t, result, 3.14)                                                                   // want "expected-actual: need to reverse actual and expected values"
-		assert.Equalf(t, result, 3.14, "msg with args %d %s", 42, "42")                                 // want "expected-actual: need to reverse actual and expected values"
-		assert.Equal(t, result, 0.707i)                                                                 // want "expected-actual: need to reverse actual and expected values"
-		assert.Equalf(t, result, 0.707i, "msg with args %d %s", 42, "42")                               // want "expected-actual: need to reverse actual and expected values"
-		assert.Equal(t, result, "raw string")                                                           // want "expected-actual: need to reverse actual and expected values"
-		assert.Equalf(t, result, "raw string", "msg with args %d %s", 42, "42")                         // want "expected-actual: need to reverse actual and expected values"
-		assert.Equal(t, result, '\U00101234')                                                           // want "expected-actual: need to reverse actual and expected values"
-		assert.Equalf(t, result, '\U00101234', "msg with args %d %s", 42, "42")                         // want "expected-actual: need to reverse actual and expected values"
-		assert.Equal(t, result, true)                                                                   // want "expected-actual: need to reverse actual and expected values"
-		assert.Equalf(t, result, true, "msg with args %d %s", 42, "42")                                 // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, result, expected)                                                             // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, result, expected, "msg with args %d %s", 42, "42")                           // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, result, expectedObj.Val)                                                      // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, result, expectedObj.Val, "msg with args %d %s", 42, "42")                    // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, result, tt.expected)                                                          // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, result, tt.expected, "msg with args %d %s", 42, "42")                        // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, result, tt.exp())                                                             // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, result, tt.exp(), "msg with args %d %s", 42, "42")                           // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, result, expectedVal())                                                        // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, result, expectedVal(), "msg with args %d %s", 42, "42")                      // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, result, []int{1, 2, 3})                                                       // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, result, []int{1, 2, 3}, "msg with args %d %s", 42, "42")                     // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, result, [3]int{1, 2, 3})                                                      // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, result, [3]int{1, 2, 3}, "msg with args %d %s", 42, "42")                    // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, result, map[string]int{"0": 1})                                               // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, result, map[string]int{"0": 1}, "msg with args %d %s", 42, "42")             // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, result, user{Name: "Rob"})                                                    // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, result, user{Name: "Rob"}, "msg with args %d %s", 42, "42")                  // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, result, struct{ Name string }{Name: "Rob"})                                   // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, result, struct{ Name string }{Name: "Rob"}, "msg with args %d %s", 42, "42") // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, result, nil)                                                                  // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, result, nil, "msg with args %d %s", 42, "42")                                // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, result, 42)                                                                   // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, result, 42, "msg with args %d %s", 42, "42")                                 // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, result, 3.14)                                                                 // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, result, 3.14, "msg with args %d %s", 42, "42")                               // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, result, 0.707i)                                                               // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, result, 0.707i, "msg with args %d %s", 42, "42")                             // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, result, "raw string")                                                         // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, result, "raw string", "msg with args %d %s", 42, "42")                       // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, result, '\U00101234')                                                         // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, result, '\U00101234', "msg with args %d %s", 42, "42")                       // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, result, true)                                                                 // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, result, true, "msg with args %d %s", 42, "42")                               // want "expected-actual: need to reverse actual and expected values"
 
-		assert.NotEqual(t, result, expected)                                                               // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualf(t, result, expected, "msg with args %d %s", 42, "42")                             // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqual(t, result, tt.expected)                                                            // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualf(t, result, tt.expected, "msg with args %d %s", 42, "42")                          // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqual(t, result, tt.exp())                                                               // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualf(t, result, tt.exp(), "msg with args %d %s", 42, "42")                             // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqual(t, result, expectedVal())                                                          // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualf(t, result, expectedVal(), "msg with args %d %s", 42, "42")                        // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqual(t, result, []int{1, 2, 3})                                                         // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualf(t, result, []int{1, 2, 3}, "msg with args %d %s", 42, "42")                       // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqual(t, result, [3]int{1, 2, 3})                                                        // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualf(t, result, [3]int{1, 2, 3}, "msg with args %d %s", 42, "42")                      // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqual(t, result, map[string]int{"0": 1})                                                 // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualf(t, result, map[string]int{"0": 1}, "msg with args %d %s", 42, "42")               // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqual(t, result, user{Name: "Anton"})                                                    // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualf(t, result, user{Name: "Anton"}, "msg with args %d %s", 42, "42")                  // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqual(t, result, struct{ Name string }{Name: "Anton"})                                   // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualf(t, result, struct{ Name string }{Name: "Anton"}, "msg with args %d %s", 42, "42") // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqual(t, result, 42)                                                                     // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualf(t, result, 42, "msg with args %d %s", 42, "42")                                   // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqual(t, result, 3.14)                                                                   // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualf(t, result, 3.14, "msg with args %d %s", 42, "42")                                 // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqual(t, result, 0.707i)                                                                 // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualf(t, result, 0.707i, "msg with args %d %s", 42, "42")                               // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqual(t, result, "raw string")                                                           // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualf(t, result, "raw string", "msg with args %d %s", 42, "42")                         // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqual(t, result, '\U00101234')                                                           // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualf(t, result, '\U00101234', "msg with args %d %s", 42, "42")                         // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqual(t, result, true)                                                                   // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualf(t, result, true, "msg with args %d %s", 42, "42")                                 // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, result, expected)                                                             // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, result, expected, "msg with args %d %s", 42, "42")                           // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, result, expectedObj.Val)                                                      // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, result, expectedObj.Val, "msg with args %d %s", 42, "42")                    // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, result, tt.expected)                                                          // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, result, tt.expected, "msg with args %d %s", 42, "42")                        // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, result, tt.exp())                                                             // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, result, tt.exp(), "msg with args %d %s", 42, "42")                           // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, result, expectedVal())                                                        // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, result, expectedVal(), "msg with args %d %s", 42, "42")                      // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, result, []int{1, 2, 3})                                                       // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, result, []int{1, 2, 3}, "msg with args %d %s", 42, "42")                     // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, result, [3]int{1, 2, 3})                                                      // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, result, [3]int{1, 2, 3}, "msg with args %d %s", 42, "42")                    // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, result, map[string]int{"0": 1})                                               // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, result, map[string]int{"0": 1}, "msg with args %d %s", 42, "42")             // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, result, user{Name: "Rob"})                                                    // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, result, user{Name: "Rob"}, "msg with args %d %s", 42, "42")                  // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, result, struct{ Name string }{Name: "Rob"})                                   // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, result, struct{ Name string }{Name: "Rob"}, "msg with args %d %s", 42, "42") // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, result, nil)                                                                  // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, result, nil, "msg with args %d %s", 42, "42")                                // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, result, 42)                                                                   // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, result, 42, "msg with args %d %s", 42, "42")                                 // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, result, 3.14)                                                                 // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, result, 3.14, "msg with args %d %s", 42, "42")                               // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, result, 0.707i)                                                               // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, result, 0.707i, "msg with args %d %s", 42, "42")                             // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, result, "raw string")                                                         // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, result, "raw string", "msg with args %d %s", 42, "42")                       // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, result, '\U00101234')                                                         // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, result, '\U00101234', "msg with args %d %s", 42, "42")                       // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, result, true)                                                                 // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, result, true, "msg with args %d %s", 42, "42")                               // want "expected-actual: need to reverse actual and expected values"
 	}
 
 	// Valid.
 	{
 		assert.Equal(t, expected, result)
 		assert.Equalf(t, expected, result, "msg with args %d %s", 42, "42")
+		assert.Equal(t, expectedObj.Val, result)
+		assert.Equalf(t, expectedObj.Val, result, "msg with args %d %s", 42, "42")
 		assert.Equal(t, tt.expected, result)
 		assert.Equalf(t, tt.expected, result, "msg with args %d %s", 42, "42")
 		assert.Equal(t, tt.exp(), result)
@@ -109,10 +120,12 @@ func TestExpectedActualChecker(t *testing.T) {
 		assert.Equalf(t, [3]int{1, 2, 3}, result, "msg with args %d %s", 42, "42")
 		assert.Equal(t, map[string]int{"0": 1}, result)
 		assert.Equalf(t, map[string]int{"0": 1}, result, "msg with args %d %s", 42, "42")
-		assert.Equal(t, user{Name: "Anton"}, result)
-		assert.Equalf(t, user{Name: "Anton"}, result, "msg with args %d %s", 42, "42")
-		assert.Equal(t, struct{ Name string }{Name: "Anton"}, result)
-		assert.Equalf(t, struct{ Name string }{Name: "Anton"}, result, "msg with args %d %s", 42, "42")
+		assert.Equal(t, user{Name: "Rob"}, result)
+		assert.Equalf(t, user{Name: "Rob"}, result, "msg with args %d %s", 42, "42")
+		assert.Equal(t, struct{ Name string }{Name: "Rob"}, result)
+		assert.Equalf(t, struct{ Name string }{Name: "Rob"}, result, "msg with args %d %s", 42, "42")
+		assert.Equal(t, nil, result)
+		assert.Equalf(t, nil, result, "msg with args %d %s", 42, "42")
 		assert.Equal(t, 42, result)
 		assert.Equalf(t, 42, result, "msg with args %d %s", 42, "42")
 		assert.Equal(t, 3.14, result)
@@ -128,6 +141,8 @@ func TestExpectedActualChecker(t *testing.T) {
 
 		assert.NotEqual(t, expected, result)
 		assert.NotEqualf(t, expected, result, "msg with args %d %s", 42, "42")
+		assert.NotEqual(t, expectedObj.Val, result)
+		assert.NotEqualf(t, expectedObj.Val, result, "msg with args %d %s", 42, "42")
 		assert.NotEqual(t, tt.expected, result)
 		assert.NotEqualf(t, tt.expected, result, "msg with args %d %s", 42, "42")
 		assert.NotEqual(t, tt.exp(), result)
@@ -140,10 +155,12 @@ func TestExpectedActualChecker(t *testing.T) {
 		assert.NotEqualf(t, [3]int{1, 2, 3}, result, "msg with args %d %s", 42, "42")
 		assert.NotEqual(t, map[string]int{"0": 1}, result)
 		assert.NotEqualf(t, map[string]int{"0": 1}, result, "msg with args %d %s", 42, "42")
-		assert.NotEqual(t, user{Name: "Anton"}, result)
-		assert.NotEqualf(t, user{Name: "Anton"}, result, "msg with args %d %s", 42, "42")
-		assert.NotEqual(t, struct{ Name string }{Name: "Anton"}, result)
-		assert.NotEqualf(t, struct{ Name string }{Name: "Anton"}, result, "msg with args %d %s", 42, "42")
+		assert.NotEqual(t, user{Name: "Rob"}, result)
+		assert.NotEqualf(t, user{Name: "Rob"}, result, "msg with args %d %s", 42, "42")
+		assert.NotEqual(t, struct{ Name string }{Name: "Rob"}, result)
+		assert.NotEqualf(t, struct{ Name string }{Name: "Rob"}, result, "msg with args %d %s", 42, "42")
+		assert.NotEqual(t, nil, result)
+		assert.NotEqualf(t, nil, result, "msg with args %d %s", 42, "42")
 		assert.NotEqual(t, 42, result)
 		assert.NotEqualf(t, 42, result, "msg with args %d %s", 42, "42")
 		assert.NotEqual(t, 3.14, result)
@@ -170,66 +187,68 @@ func TestExpectedActualChecker_Other(t *testing.T) {
 
 	// Invalid.
 	{
-		assert.EqualExportedValues(t, resultObj, expectedObj)                                                            // want "expected-actual: need to reverse actual and expected values"
-		assert.EqualExportedValuesf(t, resultObj, expectedObj, "msg with args %d %s", 42, "42")                          // want "expected-actual: need to reverse actual and expected values"
-		assert.EqualExportedValues(t, resultObj, user{Name: "Anton"})                                                    // want "expected-actual: need to reverse actual and expected values"
-		assert.EqualExportedValuesf(t, resultObj, user{Name: "Anton"}, "msg with args %d %s", 42, "42")                  // want "expected-actual: need to reverse actual and expected values"
-		assert.EqualExportedValues(t, resultObj, struct{ Name string }{Name: "Anton"})                                   // want "expected-actual: need to reverse actual and expected values"
-		assert.EqualExportedValuesf(t, resultObj, struct{ Name string }{Name: "Anton"}, "msg with args %d %s", 42, "42") // want "expected-actual: need to reverse actual and expected values"
-		assert.EqualValues(t, result, expected)                                                                          // want "expected-actual: need to reverse actual and expected values"
-		assert.EqualValuesf(t, result, expected, "msg with args %d %s", 42, "42")                                        // want "expected-actual: need to reverse actual and expected values"
-		assert.EqualValues(t, result, uint32(100))                                                                       // want "expected-actual: need to reverse actual and expected values"
-		assert.EqualValuesf(t, result, uint32(100), "msg with args %d %s", 42, "42")                                     // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualValues(t, result, expected)                                                                       // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualValuesf(t, result, expected, "msg with args %d %s", 42, "42")                                     // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualValues(t, result, uint32(100))                                                                    // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualValuesf(t, result, uint32(100), "msg with args %d %s", 42, "42")                                  // want "expected-actual: need to reverse actual and expected values"
-		assert.Exactly(t, result, expected)                                                                              // want "expected-actual: need to reverse actual and expected values"
-		assert.Exactlyf(t, result, expected, "msg with args %d %s", 42, "42")                                            // want "expected-actual: need to reverse actual and expected values"
-		assert.Exactly(t, result, int64(1))                                                                              // want "expected-actual: need to reverse actual and expected values"
-		assert.Exactlyf(t, result, int64(1), "msg with args %d %s", 42, "42")                                            // want "expected-actual: need to reverse actual and expected values"
-		assert.InDelta(t, result, expected, 1.0)                                                                         // want "expected-actual: need to reverse actual and expected values"
-		assert.InDeltaf(t, result, expected, 1.0, "msg with args %d %s", 42, "42")                                       // want "expected-actual: need to reverse actual and expected values"
-		assert.InDelta(t, result, 42.42, 1.0)                                                                            // want "expected-actual: need to reverse actual and expected values"
-		assert.InDeltaf(t, result, 42.42, 1.0, "msg with args %d %s", 42, "42")                                          // want "expected-actual: need to reverse actual and expected values"
-		assert.InDeltaMapValues(t, result, expected, 2.0)                                                                // want "expected-actual: need to reverse actual and expected values"
-		assert.InDeltaMapValuesf(t, result, expected, 2.0, "msg with args %d %s", 42, "42")                              // want "expected-actual: need to reverse actual and expected values"
-		assert.InDeltaMapValues(t, result, map[string]float64{"score": 0.99}, 2.0)                                       // want "expected-actual: need to reverse actual and expected values"
-		assert.InDeltaMapValuesf(t, result, map[string]float64{"score": 0.99}, 2.0, "msg with args %d %s", 42, "42")     // want "expected-actual: need to reverse actual and expected values"
-		assert.InDeltaSlice(t, result, expected, 1.0)                                                                    // want "expected-actual: need to reverse actual and expected values"
-		assert.InDeltaSlicef(t, result, expected, 1.0, "msg with args %d %s", 42, "42")                                  // want "expected-actual: need to reverse actual and expected values"
-		assert.InDeltaSlice(t, result, []float64{0.98, 0.99}, 1.0)                                                       // want "expected-actual: need to reverse actual and expected values"
-		assert.InDeltaSlicef(t, result, []float64{0.98, 0.99}, 1.0, "msg with args %d %s", 42, "42")                     // want "expected-actual: need to reverse actual and expected values"
-		assert.InEpsilon(t, result, expected, 0.0001)                                                                    // want "expected-actual: need to reverse actual and expected values"
-		assert.InEpsilonf(t, result, expected, 0.0001, "msg with args %d %s", 42, "42")                                  // want "expected-actual: need to reverse actual and expected values"
-		assert.InEpsilon(t, result, 42.42, 0.0001)                                                                       // want "expected-actual: need to reverse actual and expected values"
-		assert.InEpsilonf(t, result, 42.42, 0.0001, "msg with args %d %s", 42, "42")                                     // want "expected-actual: need to reverse actual and expected values"
-		assert.IsType(t, result, expected)                                                                               // want "expected-actual: need to reverse actual and expected values"
-		assert.IsTypef(t, result, expected, "msg with args %d %s", 42, "42")                                             // want "expected-actual: need to reverse actual and expected values"
-		assert.IsType(t, result, user{})                                                                                 // want "expected-actual: need to reverse actual and expected values"
-		assert.IsTypef(t, result, user{}, "msg with args %d %s", 42, "42")                                               // want "expected-actual: need to reverse actual and expected values"
-		assert.IsType(t, result, (*user)(nil))                                                                           // want "expected-actual: need to reverse actual and expected values"
-		assert.IsTypef(t, result, (*user)(nil), "msg with args %d %s", 42, "42")                                         // want "expected-actual: need to reverse actual and expected values"
-		assert.Same(t, resultPtr, expectedPtr)                                                                           // want "expected-actual: need to reverse actual and expected values"
-		assert.Samef(t, resultPtr, expectedPtr, "msg with args %d %s", 42, "42")                                         // want "expected-actual: need to reverse actual and expected values"
-		assert.Same(t, resultPtr, &value)                                                                                // want "expected-actual: need to reverse actual and expected values"
-		assert.Samef(t, resultPtr, &value, "msg with args %d %s", 42, "42")                                              // want "expected-actual: need to reverse actual and expected values"
-		assert.NotSame(t, resultPtr, expectedPtr)                                                                        // want "expected-actual: need to reverse actual and expected values"
-		assert.NotSamef(t, resultPtr, expectedPtr, "msg with args %d %s", 42, "42")                                      // want "expected-actual: need to reverse actual and expected values"
-		assert.NotSame(t, resultPtr, &value)                                                                             // want "expected-actual: need to reverse actual and expected values"
-		assert.NotSamef(t, resultPtr, &value, "msg with args %d %s", 42, "42")                                           // want "expected-actual: need to reverse actual and expected values"
-		assert.WithinDuration(t, resultTime, expectedTime, time.Second)                                                  // want "expected-actual: need to reverse actual and expected values"
-		assert.WithinDurationf(t, resultTime, expectedTime, time.Second, "msg with args %d %s", 42, "42")                // want "expected-actual: need to reverse actual and expected values"
+		assert.EqualExportedValues(t, resultObj, expectedObj)                                                                                     // want "expected-actual: need to reverse actual and expected values"
+		assert.EqualExportedValuesf(t, resultObj, expectedObj, "msg with args %d %s", 42, "42")                                                   // want "expected-actual: need to reverse actual and expected values"
+		assert.EqualExportedValues(t, resultObj, user{Name: "Rob"})                                                                               // want "expected-actual: need to reverse actual and expected values"
+		assert.EqualExportedValuesf(t, resultObj, user{Name: "Rob"}, "msg with args %d %s", 42, "42")                                             // want "expected-actual: need to reverse actual and expected values"
+		assert.EqualExportedValues(t, resultObj, struct{ Name string }{Name: "Rob"})                                                              // want "expected-actual: need to reverse actual and expected values"
+		assert.EqualExportedValuesf(t, resultObj, struct{ Name string }{Name: "Rob"}, "msg with args %d %s", 42, "42")                            // want "expected-actual: need to reverse actual and expected values"
+		assert.EqualValues(t, result, expected)                                                                                                   // want "expected-actual: need to reverse actual and expected values"
+		assert.EqualValuesf(t, result, expected, "msg with args %d %s", 42, "42")                                                                 // want "expected-actual: need to reverse actual and expected values"
+		assert.EqualValues(t, result, uint32(100))                                                                                                // want "expected-actual: need to reverse actual and expected values"
+		assert.EqualValuesf(t, result, uint32(100), "msg with args %d %s", 42, "42")                                                              // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualValues(t, result, expected)                                                                                                // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualValuesf(t, result, expected, "msg with args %d %s", 42, "42")                                                              // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualValues(t, result, uint32(100))                                                                                             // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualValuesf(t, result, uint32(100), "msg with args %d %s", 42, "42")                                                           // want "expected-actual: need to reverse actual and expected values"
+		assert.Exactly(t, result, expected)                                                                                                       // want "expected-actual: need to reverse actual and expected values"
+		assert.Exactlyf(t, result, expected, "msg with args %d %s", 42, "42")                                                                     // want "expected-actual: need to reverse actual and expected values"
+		assert.Exactly(t, result, int64(1))                                                                                                       // want "expected-actual: need to reverse actual and expected values"
+		assert.Exactlyf(t, result, int64(1), "msg with args %d %s", 42, "42")                                                                     // want "expected-actual: need to reverse actual and expected values"
+		assert.InDelta(t, result, expected, 1.0)                                                                                                  // want "expected-actual: need to reverse actual and expected values"
+		assert.InDeltaf(t, result, expected, 1.0, "msg with args %d %s", 42, "42")                                                                // want "expected-actual: need to reverse actual and expected values"
+		assert.InDelta(t, result, 42.42, 1.0)                                                                                                     // want "expected-actual: need to reverse actual and expected values"
+		assert.InDeltaf(t, result, 42.42, 1.0, "msg with args %d %s", 42, "42")                                                                   // want "expected-actual: need to reverse actual and expected values"
+		assert.InDeltaMapValues(t, result, expected, 2.0)                                                                                         // want "expected-actual: need to reverse actual and expected values"
+		assert.InDeltaMapValuesf(t, result, expected, 2.0, "msg with args %d %s", 42, "42")                                                       // want "expected-actual: need to reverse actual and expected values"
+		assert.InDeltaMapValues(t, result, map[string]float64{"score": 0.99}, 2.0)                                                                // want "expected-actual: need to reverse actual and expected values"
+		assert.InDeltaMapValuesf(t, result, map[string]float64{"score": 0.99}, 2.0, "msg with args %d %s", 42, "42")                              // want "expected-actual: need to reverse actual and expected values"
+		assert.InDeltaSlice(t, result, expected, 1.0)                                                                                             // want "expected-actual: need to reverse actual and expected values"
+		assert.InDeltaSlicef(t, result, expected, 1.0, "msg with args %d %s", 42, "42")                                                           // want "expected-actual: need to reverse actual and expected values"
+		assert.InDeltaSlice(t, result, []float64{0.98, 0.99}, 1.0)                                                                                // want "expected-actual: need to reverse actual and expected values"
+		assert.InDeltaSlicef(t, result, []float64{0.98, 0.99}, 1.0, "msg with args %d %s", 42, "42")                                              // want "expected-actual: need to reverse actual and expected values"
+		assert.InEpsilon(t, result, expected, 0.0001)                                                                                             // want "expected-actual: need to reverse actual and expected values"
+		assert.InEpsilonf(t, result, expected, 0.0001, "msg with args %d %s", 42, "42")                                                           // want "expected-actual: need to reverse actual and expected values"
+		assert.InEpsilon(t, result, 42.42, 0.0001)                                                                                                // want "expected-actual: need to reverse actual and expected values"
+		assert.InEpsilonf(t, result, 42.42, 0.0001, "msg with args %d %s", 42, "42")                                                              // want "expected-actual: need to reverse actual and expected values"
+		assert.IsType(t, result, expected)                                                                                                        // want "expected-actual: need to reverse actual and expected values"
+		assert.IsTypef(t, result, expected, "msg with args %d %s", 42, "42")                                                                      // want "expected-actual: need to reverse actual and expected values"
+		assert.IsType(t, result, user{})                                                                                                          // want "expected-actual: need to reverse actual and expected values"
+		assert.IsTypef(t, result, user{}, "msg with args %d %s", 42, "42")                                                                        // want "expected-actual: need to reverse actual and expected values"
+		assert.IsType(t, result, (*user)(nil))                                                                                                    // want "expected-actual: need to reverse actual and expected values"
+		assert.IsTypef(t, result, (*user)(nil), "msg with args %d %s", 42, "42")                                                                  // want "expected-actual: need to reverse actual and expected values"
+		assert.Same(t, resultPtr, expectedPtr)                                                                                                    // want "expected-actual: need to reverse actual and expected values"
+		assert.Samef(t, resultPtr, expectedPtr, "msg with args %d %s", 42, "42")                                                                  // want "expected-actual: need to reverse actual and expected values"
+		assert.Same(t, resultPtr, &value)                                                                                                         // want "expected-actual: need to reverse actual and expected values"
+		assert.Samef(t, resultPtr, &value, "msg with args %d %s", 42, "42")                                                                       // want "expected-actual: need to reverse actual and expected values"
+		assert.NotSame(t, resultPtr, expectedPtr)                                                                                                 // want "expected-actual: need to reverse actual and expected values"
+		assert.NotSamef(t, resultPtr, expectedPtr, "msg with args %d %s", 42, "42")                                                               // want "expected-actual: need to reverse actual and expected values"
+		assert.NotSame(t, resultPtr, &value)                                                                                                      // want "expected-actual: need to reverse actual and expected values"
+		assert.NotSamef(t, resultPtr, &value, "msg with args %d %s", 42, "42")                                                                    // want "expected-actual: need to reverse actual and expected values"
+		assert.WithinDuration(t, resultTime, expectedTime, time.Second)                                                                           // want "expected-actual: need to reverse actual and expected values"
+		assert.WithinDurationf(t, resultTime, expectedTime, time.Second, "msg with args %d %s", 42, "42")                                         // want "expected-actual: need to reverse actual and expected values"
+		assert.WithinDuration(t, resultTime, time.Date(2023, 01, 12, 11, 46, 33, 0, nil), 100*time.Millisecond)                                   // want "expected-actual: need to reverse actual and expected values"
+		assert.WithinDurationf(t, resultTime, time.Date(2023, 01, 12, 11, 46, 33, 0, nil), 100*time.Millisecond, "msg with args %d %s", 42, "42") // want "expected-actual: need to reverse actual and expected values"
 	}
 
 	// Valid.
 	{
 		assert.EqualExportedValues(t, expectedObj, resultObj)
 		assert.EqualExportedValuesf(t, expectedObj, resultObj, "msg with args %d %s", 42, "42")
-		assert.EqualExportedValues(t, user{Name: "Anton"}, resultObj)
-		assert.EqualExportedValuesf(t, user{Name: "Anton"}, resultObj, "msg with args %d %s", 42, "42")
-		assert.EqualExportedValues(t, struct{ Name string }{Name: "Anton"}, resultObj)
-		assert.EqualExportedValuesf(t, struct{ Name string }{Name: "Anton"}, resultObj, "msg with args %d %s", 42, "42")
+		assert.EqualExportedValues(t, user{Name: "Rob"}, resultObj)
+		assert.EqualExportedValuesf(t, user{Name: "Rob"}, resultObj, "msg with args %d %s", 42, "42")
+		assert.EqualExportedValues(t, struct{ Name string }{Name: "Rob"}, resultObj)
+		assert.EqualExportedValuesf(t, struct{ Name string }{Name: "Rob"}, resultObj, "msg with args %d %s", 42, "42")
 		assert.EqualValues(t, expected, result)
 		assert.EqualValuesf(t, expected, result, "msg with args %d %s", 42, "42")
 		assert.EqualValues(t, uint32(100), result)
@@ -270,6 +289,8 @@ func TestExpectedActualChecker_Other(t *testing.T) {
 		assert.NotSamef(t, &value, resultPtr, "msg with args %d %s", 42, "42")
 		assert.WithinDuration(t, expectedTime, resultTime, time.Second)
 		assert.WithinDurationf(t, expectedTime, resultTime, time.Second, "msg with args %d %s", 42, "42")
+		assert.WithinDuration(t, time.Date(2023, 01, 12, 11, 46, 33, 0, nil), resultTime, 100*time.Millisecond)
+		assert.WithinDurationf(t, time.Date(2023, 01, 12, 11, 46, 33, 0, nil), resultTime, 100*time.Millisecond, "msg with args %d %s", 42, "42")
 	}
 }
 
@@ -1027,6 +1048,8 @@ func TestExpectedActualChecker_Ignored(t *testing.T) {
 		value            int
 	)
 
+	assert.Equal(t, nil, nil)
+	assert.Equalf(t, nil, nil, "msg with args %d %s", 42, "42")
 	assert.Equal(t, "value", "value")
 	assert.Equalf(t, "value", "value", "msg with args %d %s", 42, "42")
 	assert.Equal(t, expected, expected)
@@ -1035,8 +1058,8 @@ func TestExpectedActualChecker_Ignored(t *testing.T) {
 	assert.Equalf(t, []int{1, 2}, map[int]int{1: 2}, "msg with args %d %s", 42, "42")
 	assert.NotEqual(t, result, result)
 	assert.NotEqualf(t, result, result, "msg with args %d %s", 42, "42")
-	assert.EqualExportedValues(t, user{Name: "Anton"}, struct{ Name string }{Name: "Anton"})
-	assert.EqualExportedValuesf(t, user{Name: "Anton"}, struct{ Name string }{Name: "Anton"}, "msg with args %d %s", 42, "42")
+	assert.EqualExportedValues(t, user{Name: "Rob"}, struct{ Name string }{Name: "Rob"})
+	assert.EqualExportedValuesf(t, user{Name: "Rob"}, struct{ Name string }{Name: "Rob"}, "msg with args %d %s", 42, "42")
 	assert.EqualValues(t, uint32(100), int32(100))
 	assert.EqualValuesf(t, uint32(100), int32(100), "msg with args %d %s", 42, "42")
 	assert.Exactly(t, int32(200), int64(200))
@@ -1059,4 +1082,6 @@ func TestExpectedActualChecker_Ignored(t *testing.T) {
 	assert.NotSamef(t, expectedPtr, &value, "msg with args %d %s", 42, "42")
 	assert.WithinDuration(t, expectedTime, time.Now(), time.Second)
 	assert.WithinDurationf(t, expectedTime, time.Now(), time.Second, "msg with args %d %s", 42, "42")
+	assert.WithinDuration(t, time.Date(2023, 01, 12, 11, 46, 33, 0, nil), time.Date(2023, 01, 12, 11, 46, 33, 0, nil), time.Millisecond)
+	assert.WithinDurationf(t, time.Date(2023, 01, 12, 11, 46, 33, 0, nil), time.Date(2023, 01, 12, 11, 46, 33, 0, nil), time.Millisecond, "msg with args %d %s", 42, "42")
 }

--- a/analyzer/testdata/src/checkers-default/expected-actual/expected_actual_test.go.golden
+++ b/analyzer/testdata/src/checkers-default/expected-actual/expected_actual_test.go.golden
@@ -25,78 +25,89 @@ func TestExpectedActualChecker(t *testing.T) {
 	var expected string
 	var tt testCase
 	expectedVal := func() any { return nil }
+	var expectedObj struct{ Val int }
 
 	var result any
 
 	// Invalid.
 	{
-		assert.Equal(t, expected, result)                                                               // want "expected-actual: need to reverse actual and expected values"
-		assert.Equalf(t, expected, result, "msg with args %d %s", 42, "42")                             // want "expected-actual: need to reverse actual and expected values"
-		assert.Equal(t, tt.expected, result)                                                            // want "expected-actual: need to reverse actual and expected values"
-		assert.Equalf(t, tt.expected, result, "msg with args %d %s", 42, "42")                          // want "expected-actual: need to reverse actual and expected values"
-		assert.Equal(t, tt.exp(), result)                                                               // want "expected-actual: need to reverse actual and expected values"
-		assert.Equalf(t, tt.exp(), result, "msg with args %d %s", 42, "42")                             // want "expected-actual: need to reverse actual and expected values"
-		assert.Equal(t, expectedVal(), result)                                                          // want "expected-actual: need to reverse actual and expected values"
-		assert.Equalf(t, expectedVal(), result, "msg with args %d %s", 42, "42")                        // want "expected-actual: need to reverse actual and expected values"
-		assert.Equal(t, []int{1, 2, 3}, result)                                                         // want "expected-actual: need to reverse actual and expected values"
-		assert.Equalf(t, []int{1, 2, 3}, result, "msg with args %d %s", 42, "42")                       // want "expected-actual: need to reverse actual and expected values"
-		assert.Equal(t, [3]int{1, 2, 3}, result)                                                        // want "expected-actual: need to reverse actual and expected values"
-		assert.Equalf(t, [3]int{1, 2, 3}, result, "msg with args %d %s", 42, "42")                      // want "expected-actual: need to reverse actual and expected values"
-		assert.Equal(t, map[string]int{"0": 1}, result)                                                 // want "expected-actual: need to reverse actual and expected values"
-		assert.Equalf(t, map[string]int{"0": 1}, result, "msg with args %d %s", 42, "42")               // want "expected-actual: need to reverse actual and expected values"
-		assert.Equal(t, user{Name: "Anton"}, result)                                                    // want "expected-actual: need to reverse actual and expected values"
-		assert.Equalf(t, user{Name: "Anton"}, result, "msg with args %d %s", 42, "42")                  // want "expected-actual: need to reverse actual and expected values"
-		assert.Equal(t, struct{ Name string }{Name: "Anton"}, result)                                   // want "expected-actual: need to reverse actual and expected values"
-		assert.Equalf(t, struct{ Name string }{Name: "Anton"}, result, "msg with args %d %s", 42, "42") // want "expected-actual: need to reverse actual and expected values"
-		assert.Equal(t, 42, result)                                                                     // want "expected-actual: need to reverse actual and expected values"
-		assert.Equalf(t, 42, result, "msg with args %d %s", 42, "42")                                   // want "expected-actual: need to reverse actual and expected values"
-		assert.Equal(t, 3.14, result)                                                                   // want "expected-actual: need to reverse actual and expected values"
-		assert.Equalf(t, 3.14, result, "msg with args %d %s", 42, "42")                                 // want "expected-actual: need to reverse actual and expected values"
-		assert.Equal(t, 0.707i, result)                                                                 // want "expected-actual: need to reverse actual and expected values"
-		assert.Equalf(t, 0.707i, result, "msg with args %d %s", 42, "42")                               // want "expected-actual: need to reverse actual and expected values"
-		assert.Equal(t, "raw string", result)                                                           // want "expected-actual: need to reverse actual and expected values"
-		assert.Equalf(t, "raw string", result, "msg with args %d %s", 42, "42")                         // want "expected-actual: need to reverse actual and expected values"
-		assert.Equal(t, '\U00101234', result)                                                           // want "expected-actual: need to reverse actual and expected values"
-		assert.Equalf(t, '\U00101234', result, "msg with args %d %s", 42, "42")                         // want "expected-actual: need to reverse actual and expected values"
-		assert.Equal(t, true, result)                                                                   // want "expected-actual: need to reverse actual and expected values"
-		assert.Equalf(t, true, result, "msg with args %d %s", 42, "42")                                 // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, expected, result)                                                             // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, expected, result, "msg with args %d %s", 42, "42")                           // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, expectedObj.Val, result)                                                      // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, expectedObj.Val, result, "msg with args %d %s", 42, "42")                    // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, tt.expected, result)                                                          // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, tt.expected, result, "msg with args %d %s", 42, "42")                        // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, tt.exp(), result)                                                             // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, tt.exp(), result, "msg with args %d %s", 42, "42")                           // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, expectedVal(), result)                                                        // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, expectedVal(), result, "msg with args %d %s", 42, "42")                      // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, []int{1, 2, 3}, result)                                                       // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, []int{1, 2, 3}, result, "msg with args %d %s", 42, "42")                     // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, [3]int{1, 2, 3}, result)                                                      // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, [3]int{1, 2, 3}, result, "msg with args %d %s", 42, "42")                    // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, map[string]int{"0": 1}, result)                                               // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, map[string]int{"0": 1}, result, "msg with args %d %s", 42, "42")             // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, user{Name: "Rob"}, result)                                                    // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, user{Name: "Rob"}, result, "msg with args %d %s", 42, "42")                  // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, struct{ Name string }{Name: "Rob"}, result)                                   // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, struct{ Name string }{Name: "Rob"}, result, "msg with args %d %s", 42, "42") // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, nil, result)                                                                  // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, nil, result, "msg with args %d %s", 42, "42")                                // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, 42, result)                                                                   // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, 42, result, "msg with args %d %s", 42, "42")                                 // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, 3.14, result)                                                                 // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, 3.14, result, "msg with args %d %s", 42, "42")                               // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, 0.707i, result)                                                               // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, 0.707i, result, "msg with args %d %s", 42, "42")                             // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, "raw string", result)                                                         // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, "raw string", result, "msg with args %d %s", 42, "42")                       // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, '\U00101234', result)                                                         // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, '\U00101234', result, "msg with args %d %s", 42, "42")                       // want "expected-actual: need to reverse actual and expected values"
+		assert.Equal(t, true, result)                                                                 // want "expected-actual: need to reverse actual and expected values"
+		assert.Equalf(t, true, result, "msg with args %d %s", 42, "42")                               // want "expected-actual: need to reverse actual and expected values"
 
-		assert.NotEqual(t, expected, result)                                                               // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualf(t, expected, result, "msg with args %d %s", 42, "42")                             // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqual(t, tt.expected, result)                                                            // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualf(t, tt.expected, result, "msg with args %d %s", 42, "42")                          // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqual(t, tt.exp(), result)                                                               // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualf(t, tt.exp(), result, "msg with args %d %s", 42, "42")                             // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqual(t, expectedVal(), result)                                                          // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualf(t, expectedVal(), result, "msg with args %d %s", 42, "42")                        // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqual(t, []int{1, 2, 3}, result)                                                         // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualf(t, []int{1, 2, 3}, result, "msg with args %d %s", 42, "42")                       // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqual(t, [3]int{1, 2, 3}, result)                                                        // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualf(t, [3]int{1, 2, 3}, result, "msg with args %d %s", 42, "42")                      // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqual(t, map[string]int{"0": 1}, result)                                                 // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualf(t, map[string]int{"0": 1}, result, "msg with args %d %s", 42, "42")               // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqual(t, user{Name: "Anton"}, result)                                                    // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualf(t, user{Name: "Anton"}, result, "msg with args %d %s", 42, "42")                  // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqual(t, struct{ Name string }{Name: "Anton"}, result)                                   // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualf(t, struct{ Name string }{Name: "Anton"}, result, "msg with args %d %s", 42, "42") // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqual(t, 42, result)                                                                     // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualf(t, 42, result, "msg with args %d %s", 42, "42")                                   // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqual(t, 3.14, result)                                                                   // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualf(t, 3.14, result, "msg with args %d %s", 42, "42")                                 // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqual(t, 0.707i, result)                                                                 // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualf(t, 0.707i, result, "msg with args %d %s", 42, "42")                               // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqual(t, "raw string", result)                                                           // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualf(t, "raw string", result, "msg with args %d %s", 42, "42")                         // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqual(t, '\U00101234', result)                                                           // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualf(t, '\U00101234', result, "msg with args %d %s", 42, "42")                         // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqual(t, true, result)                                                                   // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualf(t, true, result, "msg with args %d %s", 42, "42")                                 // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, expected, result)                                                             // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, expected, result, "msg with args %d %s", 42, "42")                           // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, expectedObj.Val, result)                                                      // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, expectedObj.Val, result, "msg with args %d %s", 42, "42")                    // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, tt.expected, result)                                                          // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, tt.expected, result, "msg with args %d %s", 42, "42")                        // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, tt.exp(), result)                                                             // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, tt.exp(), result, "msg with args %d %s", 42, "42")                           // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, expectedVal(), result)                                                        // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, expectedVal(), result, "msg with args %d %s", 42, "42")                      // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, []int{1, 2, 3}, result)                                                       // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, []int{1, 2, 3}, result, "msg with args %d %s", 42, "42")                     // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, [3]int{1, 2, 3}, result)                                                      // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, [3]int{1, 2, 3}, result, "msg with args %d %s", 42, "42")                    // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, map[string]int{"0": 1}, result)                                               // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, map[string]int{"0": 1}, result, "msg with args %d %s", 42, "42")             // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, user{Name: "Rob"}, result)                                                    // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, user{Name: "Rob"}, result, "msg with args %d %s", 42, "42")                  // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, struct{ Name string }{Name: "Rob"}, result)                                   // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, struct{ Name string }{Name: "Rob"}, result, "msg with args %d %s", 42, "42") // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, nil, result)                                                                  // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, nil, result, "msg with args %d %s", 42, "42")                                // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, 42, result)                                                                   // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, 42, result, "msg with args %d %s", 42, "42")                                 // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, 3.14, result)                                                                 // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, 3.14, result, "msg with args %d %s", 42, "42")                               // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, 0.707i, result)                                                               // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, 0.707i, result, "msg with args %d %s", 42, "42")                             // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, "raw string", result)                                                         // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, "raw string", result, "msg with args %d %s", 42, "42")                       // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, '\U00101234', result)                                                         // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, '\U00101234', result, "msg with args %d %s", 42, "42")                       // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqual(t, true, result)                                                                 // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualf(t, true, result, "msg with args %d %s", 42, "42")                               // want "expected-actual: need to reverse actual and expected values"
 	}
 
 	// Valid.
 	{
 		assert.Equal(t, expected, result)
 		assert.Equalf(t, expected, result, "msg with args %d %s", 42, "42")
+		assert.Equal(t, expectedObj.Val, result)
+		assert.Equalf(t, expectedObj.Val, result, "msg with args %d %s", 42, "42")
 		assert.Equal(t, tt.expected, result)
 		assert.Equalf(t, tt.expected, result, "msg with args %d %s", 42, "42")
 		assert.Equal(t, tt.exp(), result)
@@ -109,10 +120,12 @@ func TestExpectedActualChecker(t *testing.T) {
 		assert.Equalf(t, [3]int{1, 2, 3}, result, "msg with args %d %s", 42, "42")
 		assert.Equal(t, map[string]int{"0": 1}, result)
 		assert.Equalf(t, map[string]int{"0": 1}, result, "msg with args %d %s", 42, "42")
-		assert.Equal(t, user{Name: "Anton"}, result)
-		assert.Equalf(t, user{Name: "Anton"}, result, "msg with args %d %s", 42, "42")
-		assert.Equal(t, struct{ Name string }{Name: "Anton"}, result)
-		assert.Equalf(t, struct{ Name string }{Name: "Anton"}, result, "msg with args %d %s", 42, "42")
+		assert.Equal(t, user{Name: "Rob"}, result)
+		assert.Equalf(t, user{Name: "Rob"}, result, "msg with args %d %s", 42, "42")
+		assert.Equal(t, struct{ Name string }{Name: "Rob"}, result)
+		assert.Equalf(t, struct{ Name string }{Name: "Rob"}, result, "msg with args %d %s", 42, "42")
+		assert.Equal(t, nil, result)
+		assert.Equalf(t, nil, result, "msg with args %d %s", 42, "42")
 		assert.Equal(t, 42, result)
 		assert.Equalf(t, 42, result, "msg with args %d %s", 42, "42")
 		assert.Equal(t, 3.14, result)
@@ -128,6 +141,8 @@ func TestExpectedActualChecker(t *testing.T) {
 
 		assert.NotEqual(t, expected, result)
 		assert.NotEqualf(t, expected, result, "msg with args %d %s", 42, "42")
+		assert.NotEqual(t, expectedObj.Val, result)
+		assert.NotEqualf(t, expectedObj.Val, result, "msg with args %d %s", 42, "42")
 		assert.NotEqual(t, tt.expected, result)
 		assert.NotEqualf(t, tt.expected, result, "msg with args %d %s", 42, "42")
 		assert.NotEqual(t, tt.exp(), result)
@@ -140,10 +155,12 @@ func TestExpectedActualChecker(t *testing.T) {
 		assert.NotEqualf(t, [3]int{1, 2, 3}, result, "msg with args %d %s", 42, "42")
 		assert.NotEqual(t, map[string]int{"0": 1}, result)
 		assert.NotEqualf(t, map[string]int{"0": 1}, result, "msg with args %d %s", 42, "42")
-		assert.NotEqual(t, user{Name: "Anton"}, result)
-		assert.NotEqualf(t, user{Name: "Anton"}, result, "msg with args %d %s", 42, "42")
-		assert.NotEqual(t, struct{ Name string }{Name: "Anton"}, result)
-		assert.NotEqualf(t, struct{ Name string }{Name: "Anton"}, result, "msg with args %d %s", 42, "42")
+		assert.NotEqual(t, user{Name: "Rob"}, result)
+		assert.NotEqualf(t, user{Name: "Rob"}, result, "msg with args %d %s", 42, "42")
+		assert.NotEqual(t, struct{ Name string }{Name: "Rob"}, result)
+		assert.NotEqualf(t, struct{ Name string }{Name: "Rob"}, result, "msg with args %d %s", 42, "42")
+		assert.NotEqual(t, nil, result)
+		assert.NotEqualf(t, nil, result, "msg with args %d %s", 42, "42")
 		assert.NotEqual(t, 42, result)
 		assert.NotEqualf(t, 42, result, "msg with args %d %s", 42, "42")
 		assert.NotEqual(t, 3.14, result)
@@ -170,66 +187,68 @@ func TestExpectedActualChecker_Other(t *testing.T) {
 
 	// Invalid.
 	{
-		assert.EqualExportedValues(t, expectedObj, resultObj)                                                            // want "expected-actual: need to reverse actual and expected values"
-		assert.EqualExportedValuesf(t, expectedObj, resultObj, "msg with args %d %s", 42, "42")                          // want "expected-actual: need to reverse actual and expected values"
-		assert.EqualExportedValues(t, user{Name: "Anton"}, resultObj)                                                    // want "expected-actual: need to reverse actual and expected values"
-		assert.EqualExportedValuesf(t, user{Name: "Anton"}, resultObj, "msg with args %d %s", 42, "42")                  // want "expected-actual: need to reverse actual and expected values"
-		assert.EqualExportedValues(t, struct{ Name string }{Name: "Anton"}, resultObj)                                   // want "expected-actual: need to reverse actual and expected values"
-		assert.EqualExportedValuesf(t, struct{ Name string }{Name: "Anton"}, resultObj, "msg with args %d %s", 42, "42") // want "expected-actual: need to reverse actual and expected values"
-		assert.EqualValues(t, expected, result)                                                                          // want "expected-actual: need to reverse actual and expected values"
-		assert.EqualValuesf(t, expected, result, "msg with args %d %s", 42, "42")                                        // want "expected-actual: need to reverse actual and expected values"
-		assert.EqualValues(t, uint32(100), result)                                                                       // want "expected-actual: need to reverse actual and expected values"
-		assert.EqualValuesf(t, uint32(100), result, "msg with args %d %s", 42, "42")                                     // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualValues(t, expected, result)                                                                       // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualValuesf(t, expected, result, "msg with args %d %s", 42, "42")                                     // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualValues(t, uint32(100), result)                                                                    // want "expected-actual: need to reverse actual and expected values"
-		assert.NotEqualValuesf(t, uint32(100), result, "msg with args %d %s", 42, "42")                                  // want "expected-actual: need to reverse actual and expected values"
-		assert.Exactly(t, expected, result)                                                                              // want "expected-actual: need to reverse actual and expected values"
-		assert.Exactlyf(t, expected, result, "msg with args %d %s", 42, "42")                                            // want "expected-actual: need to reverse actual and expected values"
-		assert.Exactly(t, int64(1), result)                                                                              // want "expected-actual: need to reverse actual and expected values"
-		assert.Exactlyf(t, int64(1), result, "msg with args %d %s", 42, "42")                                            // want "expected-actual: need to reverse actual and expected values"
-		assert.InDelta(t, expected, result, 1.0)                                                                         // want "expected-actual: need to reverse actual and expected values"
-		assert.InDeltaf(t, expected, result, 1.0, "msg with args %d %s", 42, "42")                                       // want "expected-actual: need to reverse actual and expected values"
-		assert.InDelta(t, 42.42, result, 1.0)                                                                            // want "expected-actual: need to reverse actual and expected values"
-		assert.InDeltaf(t, 42.42, result, 1.0, "msg with args %d %s", 42, "42")                                          // want "expected-actual: need to reverse actual and expected values"
-		assert.InDeltaMapValues(t, expected, result, 2.0)                                                                // want "expected-actual: need to reverse actual and expected values"
-		assert.InDeltaMapValuesf(t, expected, result, 2.0, "msg with args %d %s", 42, "42")                              // want "expected-actual: need to reverse actual and expected values"
-		assert.InDeltaMapValues(t, map[string]float64{"score": 0.99}, result, 2.0)                                       // want "expected-actual: need to reverse actual and expected values"
-		assert.InDeltaMapValuesf(t, map[string]float64{"score": 0.99}, result, 2.0, "msg with args %d %s", 42, "42")     // want "expected-actual: need to reverse actual and expected values"
-		assert.InDeltaSlice(t, expected, result, 1.0)                                                                    // want "expected-actual: need to reverse actual and expected values"
-		assert.InDeltaSlicef(t, expected, result, 1.0, "msg with args %d %s", 42, "42")                                  // want "expected-actual: need to reverse actual and expected values"
-		assert.InDeltaSlice(t, []float64{0.98, 0.99}, result, 1.0)                                                       // want "expected-actual: need to reverse actual and expected values"
-		assert.InDeltaSlicef(t, []float64{0.98, 0.99}, result, 1.0, "msg with args %d %s", 42, "42")                     // want "expected-actual: need to reverse actual and expected values"
-		assert.InEpsilon(t, expected, result, 0.0001)                                                                    // want "expected-actual: need to reverse actual and expected values"
-		assert.InEpsilonf(t, expected, result, 0.0001, "msg with args %d %s", 42, "42")                                  // want "expected-actual: need to reverse actual and expected values"
-		assert.InEpsilon(t, 42.42, result, 0.0001)                                                                       // want "expected-actual: need to reverse actual and expected values"
-		assert.InEpsilonf(t, 42.42, result, 0.0001, "msg with args %d %s", 42, "42")                                     // want "expected-actual: need to reverse actual and expected values"
-		assert.IsType(t, expected, result)                                                                               // want "expected-actual: need to reverse actual and expected values"
-		assert.IsTypef(t, expected, result, "msg with args %d %s", 42, "42")                                             // want "expected-actual: need to reverse actual and expected values"
-		assert.IsType(t, user{}, result)                                                                                 // want "expected-actual: need to reverse actual and expected values"
-		assert.IsTypef(t, user{}, result, "msg with args %d %s", 42, "42")                                               // want "expected-actual: need to reverse actual and expected values"
-		assert.IsType(t, (*user)(nil), result)                                                                           // want "expected-actual: need to reverse actual and expected values"
-		assert.IsTypef(t, (*user)(nil), result, "msg with args %d %s", 42, "42")                                         // want "expected-actual: need to reverse actual and expected values"
-		assert.Same(t, expectedPtr, resultPtr)                                                                           // want "expected-actual: need to reverse actual and expected values"
-		assert.Samef(t, expectedPtr, resultPtr, "msg with args %d %s", 42, "42")                                         // want "expected-actual: need to reverse actual and expected values"
-		assert.Same(t, &value, resultPtr)                                                                                // want "expected-actual: need to reverse actual and expected values"
-		assert.Samef(t, &value, resultPtr, "msg with args %d %s", 42, "42")                                              // want "expected-actual: need to reverse actual and expected values"
-		assert.NotSame(t, expectedPtr, resultPtr)                                                                        // want "expected-actual: need to reverse actual and expected values"
-		assert.NotSamef(t, expectedPtr, resultPtr, "msg with args %d %s", 42, "42")                                      // want "expected-actual: need to reverse actual and expected values"
-		assert.NotSame(t, &value, resultPtr)                                                                             // want "expected-actual: need to reverse actual and expected values"
-		assert.NotSamef(t, &value, resultPtr, "msg with args %d %s", 42, "42")                                           // want "expected-actual: need to reverse actual and expected values"
-		assert.WithinDuration(t, expectedTime, resultTime, time.Second)                                                  // want "expected-actual: need to reverse actual and expected values"
-		assert.WithinDurationf(t, expectedTime, resultTime, time.Second, "msg with args %d %s", 42, "42")                // want "expected-actual: need to reverse actual and expected values"
+		assert.EqualExportedValues(t, expectedObj, resultObj)                                                                                     // want "expected-actual: need to reverse actual and expected values"
+		assert.EqualExportedValuesf(t, expectedObj, resultObj, "msg with args %d %s", 42, "42")                                                   // want "expected-actual: need to reverse actual and expected values"
+		assert.EqualExportedValues(t, user{Name: "Rob"}, resultObj)                                                                               // want "expected-actual: need to reverse actual and expected values"
+		assert.EqualExportedValuesf(t, user{Name: "Rob"}, resultObj, "msg with args %d %s", 42, "42")                                             // want "expected-actual: need to reverse actual and expected values"
+		assert.EqualExportedValues(t, struct{ Name string }{Name: "Rob"}, resultObj)                                                              // want "expected-actual: need to reverse actual and expected values"
+		assert.EqualExportedValuesf(t, struct{ Name string }{Name: "Rob"}, resultObj, "msg with args %d %s", 42, "42")                            // want "expected-actual: need to reverse actual and expected values"
+		assert.EqualValues(t, expected, result)                                                                                                   // want "expected-actual: need to reverse actual and expected values"
+		assert.EqualValuesf(t, expected, result, "msg with args %d %s", 42, "42")                                                                 // want "expected-actual: need to reverse actual and expected values"
+		assert.EqualValues(t, uint32(100), result)                                                                                                // want "expected-actual: need to reverse actual and expected values"
+		assert.EqualValuesf(t, uint32(100), result, "msg with args %d %s", 42, "42")                                                              // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualValues(t, expected, result)                                                                                                // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualValuesf(t, expected, result, "msg with args %d %s", 42, "42")                                                              // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualValues(t, uint32(100), result)                                                                                             // want "expected-actual: need to reverse actual and expected values"
+		assert.NotEqualValuesf(t, uint32(100), result, "msg with args %d %s", 42, "42")                                                           // want "expected-actual: need to reverse actual and expected values"
+		assert.Exactly(t, expected, result)                                                                                                       // want "expected-actual: need to reverse actual and expected values"
+		assert.Exactlyf(t, expected, result, "msg with args %d %s", 42, "42")                                                                     // want "expected-actual: need to reverse actual and expected values"
+		assert.Exactly(t, int64(1), result)                                                                                                       // want "expected-actual: need to reverse actual and expected values"
+		assert.Exactlyf(t, int64(1), result, "msg with args %d %s", 42, "42")                                                                     // want "expected-actual: need to reverse actual and expected values"
+		assert.InDelta(t, expected, result, 1.0)                                                                                                  // want "expected-actual: need to reverse actual and expected values"
+		assert.InDeltaf(t, expected, result, 1.0, "msg with args %d %s", 42, "42")                                                                // want "expected-actual: need to reverse actual and expected values"
+		assert.InDelta(t, 42.42, result, 1.0)                                                                                                     // want "expected-actual: need to reverse actual and expected values"
+		assert.InDeltaf(t, 42.42, result, 1.0, "msg with args %d %s", 42, "42")                                                                   // want "expected-actual: need to reverse actual and expected values"
+		assert.InDeltaMapValues(t, expected, result, 2.0)                                                                                         // want "expected-actual: need to reverse actual and expected values"
+		assert.InDeltaMapValuesf(t, expected, result, 2.0, "msg with args %d %s", 42, "42")                                                       // want "expected-actual: need to reverse actual and expected values"
+		assert.InDeltaMapValues(t, map[string]float64{"score": 0.99}, result, 2.0)                                                                // want "expected-actual: need to reverse actual and expected values"
+		assert.InDeltaMapValuesf(t, map[string]float64{"score": 0.99}, result, 2.0, "msg with args %d %s", 42, "42")                              // want "expected-actual: need to reverse actual and expected values"
+		assert.InDeltaSlice(t, expected, result, 1.0)                                                                                             // want "expected-actual: need to reverse actual and expected values"
+		assert.InDeltaSlicef(t, expected, result, 1.0, "msg with args %d %s", 42, "42")                                                           // want "expected-actual: need to reverse actual and expected values"
+		assert.InDeltaSlice(t, []float64{0.98, 0.99}, result, 1.0)                                                                                // want "expected-actual: need to reverse actual and expected values"
+		assert.InDeltaSlicef(t, []float64{0.98, 0.99}, result, 1.0, "msg with args %d %s", 42, "42")                                              // want "expected-actual: need to reverse actual and expected values"
+		assert.InEpsilon(t, expected, result, 0.0001)                                                                                             // want "expected-actual: need to reverse actual and expected values"
+		assert.InEpsilonf(t, expected, result, 0.0001, "msg with args %d %s", 42, "42")                                                           // want "expected-actual: need to reverse actual and expected values"
+		assert.InEpsilon(t, 42.42, result, 0.0001)                                                                                                // want "expected-actual: need to reverse actual and expected values"
+		assert.InEpsilonf(t, 42.42, result, 0.0001, "msg with args %d %s", 42, "42")                                                              // want "expected-actual: need to reverse actual and expected values"
+		assert.IsType(t, expected, result)                                                                                                        // want "expected-actual: need to reverse actual and expected values"
+		assert.IsTypef(t, expected, result, "msg with args %d %s", 42, "42")                                                                      // want "expected-actual: need to reverse actual and expected values"
+		assert.IsType(t, user{}, result)                                                                                                          // want "expected-actual: need to reverse actual and expected values"
+		assert.IsTypef(t, user{}, result, "msg with args %d %s", 42, "42")                                                                        // want "expected-actual: need to reverse actual and expected values"
+		assert.IsType(t, (*user)(nil), result)                                                                                                    // want "expected-actual: need to reverse actual and expected values"
+		assert.IsTypef(t, (*user)(nil), result, "msg with args %d %s", 42, "42")                                                                  // want "expected-actual: need to reverse actual and expected values"
+		assert.Same(t, expectedPtr, resultPtr)                                                                                                    // want "expected-actual: need to reverse actual and expected values"
+		assert.Samef(t, expectedPtr, resultPtr, "msg with args %d %s", 42, "42")                                                                  // want "expected-actual: need to reverse actual and expected values"
+		assert.Same(t, &value, resultPtr)                                                                                                         // want "expected-actual: need to reverse actual and expected values"
+		assert.Samef(t, &value, resultPtr, "msg with args %d %s", 42, "42")                                                                       // want "expected-actual: need to reverse actual and expected values"
+		assert.NotSame(t, expectedPtr, resultPtr)                                                                                                 // want "expected-actual: need to reverse actual and expected values"
+		assert.NotSamef(t, expectedPtr, resultPtr, "msg with args %d %s", 42, "42")                                                               // want "expected-actual: need to reverse actual and expected values"
+		assert.NotSame(t, &value, resultPtr)                                                                                                      // want "expected-actual: need to reverse actual and expected values"
+		assert.NotSamef(t, &value, resultPtr, "msg with args %d %s", 42, "42")                                                                    // want "expected-actual: need to reverse actual and expected values"
+		assert.WithinDuration(t, expectedTime, resultTime, time.Second)                                                                           // want "expected-actual: need to reverse actual and expected values"
+		assert.WithinDurationf(t, expectedTime, resultTime, time.Second, "msg with args %d %s", 42, "42")                                         // want "expected-actual: need to reverse actual and expected values"
+		assert.WithinDuration(t, time.Date(2023, 01, 12, 11, 46, 33, 0, nil), resultTime, 100*time.Millisecond)                                   // want "expected-actual: need to reverse actual and expected values"
+		assert.WithinDurationf(t, time.Date(2023, 01, 12, 11, 46, 33, 0, nil), resultTime, 100*time.Millisecond, "msg with args %d %s", 42, "42") // want "expected-actual: need to reverse actual and expected values"
 	}
 
 	// Valid.
 	{
 		assert.EqualExportedValues(t, expectedObj, resultObj)
 		assert.EqualExportedValuesf(t, expectedObj, resultObj, "msg with args %d %s", 42, "42")
-		assert.EqualExportedValues(t, user{Name: "Anton"}, resultObj)
-		assert.EqualExportedValuesf(t, user{Name: "Anton"}, resultObj, "msg with args %d %s", 42, "42")
-		assert.EqualExportedValues(t, struct{ Name string }{Name: "Anton"}, resultObj)
-		assert.EqualExportedValuesf(t, struct{ Name string }{Name: "Anton"}, resultObj, "msg with args %d %s", 42, "42")
+		assert.EqualExportedValues(t, user{Name: "Rob"}, resultObj)
+		assert.EqualExportedValuesf(t, user{Name: "Rob"}, resultObj, "msg with args %d %s", 42, "42")
+		assert.EqualExportedValues(t, struct{ Name string }{Name: "Rob"}, resultObj)
+		assert.EqualExportedValuesf(t, struct{ Name string }{Name: "Rob"}, resultObj, "msg with args %d %s", 42, "42")
 		assert.EqualValues(t, expected, result)
 		assert.EqualValuesf(t, expected, result, "msg with args %d %s", 42, "42")
 		assert.EqualValues(t, uint32(100), result)
@@ -270,6 +289,8 @@ func TestExpectedActualChecker_Other(t *testing.T) {
 		assert.NotSamef(t, &value, resultPtr, "msg with args %d %s", 42, "42")
 		assert.WithinDuration(t, expectedTime, resultTime, time.Second)
 		assert.WithinDurationf(t, expectedTime, resultTime, time.Second, "msg with args %d %s", 42, "42")
+		assert.WithinDuration(t, time.Date(2023, 01, 12, 11, 46, 33, 0, nil), resultTime, 100*time.Millisecond)
+		assert.WithinDurationf(t, time.Date(2023, 01, 12, 11, 46, 33, 0, nil), resultTime, 100*time.Millisecond, "msg with args %d %s", 42, "42")
 	}
 }
 
@@ -1027,6 +1048,8 @@ func TestExpectedActualChecker_Ignored(t *testing.T) {
 		value            int
 	)
 
+	assert.Equal(t, nil, nil)
+	assert.Equalf(t, nil, nil, "msg with args %d %s", 42, "42")
 	assert.Equal(t, "value", "value")
 	assert.Equalf(t, "value", "value", "msg with args %d %s", 42, "42")
 	assert.Equal(t, expected, expected)
@@ -1035,8 +1058,8 @@ func TestExpectedActualChecker_Ignored(t *testing.T) {
 	assert.Equalf(t, []int{1, 2}, map[int]int{1: 2}, "msg with args %d %s", 42, "42")
 	assert.NotEqual(t, result, result)
 	assert.NotEqualf(t, result, result, "msg with args %d %s", 42, "42")
-	assert.EqualExportedValues(t, user{Name: "Anton"}, struct{ Name string }{Name: "Anton"})
-	assert.EqualExportedValuesf(t, user{Name: "Anton"}, struct{ Name string }{Name: "Anton"}, "msg with args %d %s", 42, "42")
+	assert.EqualExportedValues(t, user{Name: "Rob"}, struct{ Name string }{Name: "Rob"})
+	assert.EqualExportedValuesf(t, user{Name: "Rob"}, struct{ Name string }{Name: "Rob"}, "msg with args %d %s", 42, "42")
 	assert.EqualValues(t, uint32(100), int32(100))
 	assert.EqualValuesf(t, uint32(100), int32(100), "msg with args %d %s", 42, "42")
 	assert.Exactly(t, int32(200), int64(200))
@@ -1059,4 +1082,6 @@ func TestExpectedActualChecker_Ignored(t *testing.T) {
 	assert.NotSamef(t, expectedPtr, &value, "msg with args %d %s", 42, "42")
 	assert.WithinDuration(t, expectedTime, time.Now(), time.Second)
 	assert.WithinDurationf(t, expectedTime, time.Now(), time.Second, "msg with args %d %s", 42, "42")
+	assert.WithinDuration(t, time.Date(2023, 01, 12, 11, 46, 33, 0, nil), time.Date(2023, 01, 12, 11, 46, 33, 0, nil), time.Millisecond)
+	assert.WithinDurationf(t, time.Date(2023, 01, 12, 11, 46, 33, 0, nil), time.Date(2023, 01, 12, 11, 46, 33, 0, nil), time.Millisecond, "msg with args %d %s", 42, "42")
 }

--- a/internal/checkers/bool_compare.go
+++ b/internal/checkers/bool_compare.go
@@ -13,7 +13,10 @@ import (
 // BoolCompare detects situations like
 //
 //	assert.Equal(t, false, result)
-//	assert.NotEqual(t, result, true)
+//	assert.EqualValues(t, false, result)
+//	assert.Exactly(t, false, result)
+//	assert.NotEqual(t, true, result)
+//	assert.NotEqualValues(t, true, result)
 //	assert.False(t, !result)
 //	assert.True(t, result == true)
 //	...

--- a/internal/checkers/compares.go
+++ b/internal/checkers/compares.go
@@ -18,6 +18,7 @@ import (
 //	assert.True(t, a >= b)
 //	assert.True(t, a < b)
 //	assert.True(t, a <= b)
+//	assert.False(t, a == b)
 //	...
 //
 // and requires

--- a/internal/checkers/empty.go
+++ b/internal/checkers/empty.go
@@ -15,9 +15,16 @@ import (
 //
 //	assert.Len(t, arr, 0)
 //	assert.Equal(t, 0, len(arr))
+//	assert.EqualValues(t, 0, len(arr))
+//	assert.Exactly(t, 0, len(arr))
+//	assert.LessOrEqual(t, len(arr), 0)
+//	assert.GreaterOrEqual(t, 0, len(arr))
+//	assert.Less(t, len(arr), 1)
+//	assert.Greater(t, 1, len(arr))
 //	assert.NotEqual(t, 0, len(arr))
-//	assert.GreaterOrEqual(t, len(arr), 1)
-//	...
+//	assert.NotEqualValues(t, 0, len(arr))
+//	assert.Less(t, 0, len(arr))
+//	assert.Greater(t, len(arr), 0)
 //
 // and requires
 //
@@ -116,13 +123,13 @@ func (checker Empty) checkNotEmpty(pass *analysis.Pass, call *CallMeta) *analysi
 			return newUseNotEmptyDiagnostic(a.Pos(), b.End(), lenArg)
 		}
 
-	case "Greater":
-		if lenArg, ok := isBuiltinLenCall(pass, a); ok && isZero(b) {
+	case "Less":
+		if lenArg, ok := isBuiltinLenCall(pass, b); ok && isZero(a) {
 			return newUseNotEmptyDiagnostic(a.Pos(), b.End(), lenArg)
 		}
 
-	case "Less":
-		if lenArg, ok := isBuiltinLenCall(pass, b); ok && isZero(a) {
+	case "Greater":
+		if lenArg, ok := isBuiltinLenCall(pass, a); ok && isZero(b) {
 			return newUseNotEmptyDiagnostic(a.Pos(), b.End(), lenArg)
 		}
 	}

--- a/internal/checkers/error_nil.go
+++ b/internal/checkers/error_nil.go
@@ -14,9 +14,12 @@ import (
 //
 //	assert.Nil(t, err)
 //	assert.NotNil(t, err)
-//	assert.Equal(t, err, nil)
-//	assert.NotEqual(t, err, nil)
+//	assert.Equal(t, nil, err)
+//	assert.EqualValues(t, nil, err)
+//	assert.Exactly(t, nil, err)
 //	assert.ErrorIs(t, err, nil)
+//	assert.NotEqual(t, nil, err)
+//	assert.NotEqualValues(t, nil, err)
 //	assert.NotErrorIs(t, err, nil)
 //
 // and requires
@@ -37,14 +40,14 @@ func (checker ErrorNil) Check(pass *analysis.Pass, call *CallMeta) *analysis.Dia
 
 	proposedFn, survivingArg, replacementEndPos := func() (string, ast.Expr, token.Pos) {
 		switch call.Fn.NameFTrimmed {
-		case "NotNil":
-			if len(call.Args) >= 1 && isError(pass, call.Args[0]) {
-				return errorFn, call.Args[0], call.Args[0].End()
-			}
-
 		case "Nil":
 			if len(call.Args) >= 1 && isError(pass, call.Args[0]) {
 				return noErrorFn, call.Args[0], call.Args[0].End()
+			}
+
+		case "NotNil":
+			if len(call.Args) >= 1 && isError(pass, call.Args[0]) {
+				return errorFn, call.Args[0], call.Args[0].End()
 			}
 
 		case "Equal", "EqualValues", "Exactly", "ErrorIs":

--- a/internal/checkers/expected_actual.go
+++ b/internal/checkers/expected_actual.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 
 	"golang.org/x/tools/go/analysis"
+
+	"github.com/Antonboom/testifylint/internal/analysisutil"
 )
 
 // DefaultExpectedVarPattern matches variables with "expected" or "wanted" prefix or suffix in the name.
@@ -15,11 +17,29 @@ var DefaultExpectedVarPattern = regexp.MustCompile(
 
 // ExpectedActual detects situation like
 //
-//	assert.NotEqual(t, result, "expected value")
+//	assert.Equal(t, result, expected)
+//	assert.EqualExportedValues(t, resultObj, User{Name: "Anton"})
+//	assert.EqualValues(t, result, 42)
+//	assert.Exactly(t, result, int64(42))
+//	assert.JSONEq(t, result, `{"version": 3}`)
+//	assert.InDelta(t, result, 42.42, 1.0)
+//	assert.InDeltaMapValues(t, result, map[string]float64{"score": 0.99}, 1.0)
+//	assert.InDeltaSlice(t, result, []float64{0.98, 0.99}, 1.0)
+//	assert.InEpsilon(t, result, 42.42, 0.0001)
+//	assert.IsType(t, result, (*User)(nil))
+//	assert.NotEqual(t, result, "expected")
+//	assert.NotEqualValues(t, result, "expected")
+//	assert.NotSame(t, resultPtr, &value)
+//	assert.Same(t, resultPtr, &value)
+//	assert.WithinDuration(t, resultTime, time.Date(2023, 01, 12, 11, 46, 33, 0, nil), time.Second)
+//	assert.YAMLEq(t, result, "version: '3'")
 //
 // and requires
 //
-//	assert.NotEqual(t, "expected value", result)
+//	assert.Equal(t, expected, result)
+//	assert.EqualExportedValues(t, User{Name: "Anton"}, resultObj)
+//	assert.EqualValues(t, 42, result)
+//	...
 type ExpectedActual struct {
 	expVarPattern *regexp.Regexp
 }
@@ -94,7 +114,7 @@ func (checker ExpectedActual) isExpectedValueCandidate(pass *analysis.Pass, expr
 	case *ast.CallExpr:
 		return isParenExpr(v) ||
 			isCastedBasicLitOrExpectedValue(v, checker.expVarPattern) ||
-			isExpectedValueFactory(v, checker.expVarPattern)
+			isExpectedValueFactory(pass, v, checker.expVarPattern)
 	}
 
 	return isBasicLit(expr) ||
@@ -102,6 +122,7 @@ func (checker ExpectedActual) isExpectedValueCandidate(pass *analysis.Pass, expr
 		isTypedConst(pass, expr) ||
 		isAddressOperation(expr) ||
 		isIdentNamedAsExpected(checker.expVarPattern, expr) ||
+		isStructVarNamedAsExpected(checker.expVarPattern, expr) ||
 		isStructFieldNamedAsExpected(checker.expVarPattern, expr)
 }
 
@@ -133,15 +154,16 @@ func isCastedBasicLitOrExpectedValue(ce *ast.CallExpr, pattern *regexp.Regexp) b
 	return false
 }
 
-func isExpectedValueFactory(ce *ast.CallExpr, pattern *regexp.Regexp) bool {
-	if len(ce.Args) != 0 {
-		return false
-	}
-
+func isExpectedValueFactory(pass *analysis.Pass, ce *ast.CallExpr, pattern *regexp.Regexp) bool {
 	switch fn := ce.Fun.(type) {
 	case *ast.Ident:
 		return pattern.MatchString(fn.Name)
+
 	case *ast.SelectorExpr:
+		timeDateFn := analysisutil.ObjectOf(pass.Pkg, "time", "Date")
+		if timeDateFn != nil && analysisutil.IsObj(pass.TypesInfo, fn.Sel, timeDateFn) {
+			return true
+		}
 		return pattern.MatchString(fn.Sel.Name)
 	}
 	return false
@@ -175,6 +197,11 @@ func isAddressOperation(e ast.Expr) bool {
 func isIdentNamedAsExpected(pattern *regexp.Regexp, e ast.Expr) bool {
 	id, ok := e.(*ast.Ident)
 	return ok && pattern.MatchString(id.Name)
+}
+
+func isStructVarNamedAsExpected(pattern *regexp.Regexp, e ast.Expr) bool {
+	s, ok := e.(*ast.SelectorExpr)
+	return ok && isIdentNamedAsExpected(pattern, s.X)
 }
 
 func isStructFieldNamedAsExpected(pattern *regexp.Regexp, e ast.Expr) bool {

--- a/internal/checkers/float_compare.go
+++ b/internal/checkers/float_compare.go
@@ -11,13 +11,15 @@ import (
 
 // FloatCompare detects situation like
 //
-//	assert.Equal(t, 42.42, a)
-//	assert.True(t, a == 42.42)
-//	assert.False(t, a != 42.42)
+//	assert.Equal(t, 42.42, result)
+//	assert.EqualValues(t, 42.42, result)
+//	assert.Exactly(t, 42.42, result)
+//	assert.True(t, result == 42.42)
+//	assert.False(t, result != 42.42)
 //
 // and requires
 //
-//	assert.InEpsilon(t, 42.42, a, 0.0001) // Or assert.InDelta
+//	assert.InEpsilon(t, 42.42, result, 0.0001) // Or assert.InDelta
 type FloatCompare struct{}
 
 // NewFloatCompare constructs FloatCompare checker.

--- a/internal/checkers/len.go
+++ b/internal/checkers/len.go
@@ -10,6 +10,8 @@ import (
 // Len detects situations like
 //
 //	assert.Equal(t, 3, len(arr))
+//	assert.EqualValues(t, 3, len(arr))
+//	assert.Exactly(t, 3, len(arr))
 //	assert.True(t, len(arr) == 3)
 //
 // and requires

--- a/internal/checkers/nil_compare.go
+++ b/internal/checkers/nil_compare.go
@@ -10,8 +10,11 @@ import (
 
 // NilCompare detects situations like
 //
-//	assert.Equal(t, value, nil)
-//	assert.NotEqual(t, value, nil)
+//	assert.Equal(t, nil, value)
+//	assert.EqualValues(t, nil, value)
+//	assert.Exactly(t, nil, value)
+//	assert.NotEqual(t, nil, value)
+//	assert.NotEqualValues(t, nil, value)
 //
 // and requires
 //

--- a/internal/checkers/require_error.go
+++ b/internal/checkers/require_error.go
@@ -14,15 +14,20 @@ const requireErrorReport = "for error assertions use require"
 
 // RequireError detects situations like
 //
+//	assert.Error(t, err) // s.Error(err), s.Assert().Error(t, err)
+//	assert.ErrorIs(t, err, io.EOF)
+//	assert.ErrorAs(t, err, &target)
+//	assert.EqualError(t, err, "end of file")
+//	assert.ErrorContains(t, err, "end of file")
 //	assert.NoError(t, err)
-//	s.ErrorIs(err, io.EOF)
-//	s.Assert().Error(err)
+//	assert.NotErrorIs(t, err, io.EOF)
 //
 // and requires
 //
-//	require.NoError(t, err)
-//	s.Require().ErrorIs(err, io.EOF)
-//	s.Require().Error(err)
+//	require.Error(t, err) // s.Require().Error(err), s.Require().Error(t, err)
+//	require.ErrorIs(t, err, io.EOF)
+//	require.ErrorAs(t, err, &target)
+//	...
 //
 // RequireError ignores:
 // - assertion in the `if` condition;

--- a/internal/checkers/require_error.go
+++ b/internal/checkers/require_error.go
@@ -14,7 +14,7 @@ const requireErrorReport = "for error assertions use require"
 
 // RequireError detects situations like
 //
-//	assert.Error(t, err) // s.Error(err), s.Assert().Error(t, err)
+//	assert.Error(t, err) // s.Error(err), s.Assert().Error(err)
 //	assert.ErrorIs(t, err, io.EOF)
 //	assert.ErrorAs(t, err, &target)
 //	assert.EqualError(t, err, "end of file")
@@ -24,7 +24,7 @@ const requireErrorReport = "for error assertions use require"
 //
 // and requires
 //
-//	require.Error(t, err) // s.Require().Error(err), s.Require().Error(t, err)
+//	require.Error(t, err) // s.Require().Error(err), s.Require().Error(err)
 //	require.ErrorIs(t, err, io.EOF)
 //	require.ErrorAs(t, err, &target)
 //	...

--- a/internal/testgen/gen_expected_actual.go
+++ b/internal/testgen/gen_expected_actual.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	"github.com/Antonboom/testifylint/internal/checkers"
 	"strings"
 	"text/template"
+
+	"github.com/Antonboom/testifylint/internal/checkers"
 )
 
 type ExpectedActualTestsGenerator struct{}


### PR DESCRIPTION
Also support new cases for `expected-actual`:

1. `time.Date()` call
2. Using expected object like `expectedObj.Field`