### PR TITLE
organize dev tools installation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,9 @@
 ### 1) Install developer tools
 
 ```bash
-# https://taskfile.dev/installation/
-$ go install github.com/go-task/task/v3/cmd/task@latest
-$ task tools:install
+$ make dev/tools
+go install github.com/go-task/task/v3/cmd/task@latest
+task tools:install
 Install dev tools...
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+GOBIN= ${GOPATH}/bin
+
+# https://taskfile.dev/installation/
+${GOBIN}/task:
+	go install github.com/go-task/task/v3/cmd/task@latest
+
+.PHONY : install
+install: ${GOBIN}/task
+
+.PHONY : dev/tools
+dev/tools: install
+	task tools:install
+
+.PHONY : clean
+clean: 
+	rm -f ${GOBIN}/task

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -14,26 +14,18 @@ tasks:
   default:
     cmds:
       - task: tidy
-      - task: fmt
       - task: lint
       - task: test
       - task: install
 
   tools:install:
     - echo "Install dev tools..."
-    - go install github.com/daixiang0/gci@latest
-    - go install mvdan.cc/gofumpt@latest
+    - go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 
   tidy:
     cmds:
       - echo "Tidy..."
       - go mod tidy
-
-  fmt:
-    cmds:
-      - echo "Fmt..."
-      - gofumpt -w .
-      - gci write -s standard -s default -s "Prefix(github.com/Antonboom/testifylint)" . 2> /dev/null
 
   lint:
     cmds:


### PR DESCRIPTION
This provides a Makefile to setup dev tools with only one target:
```bash
make dev/tools
```

It removes goimports (duplication with gci) and gofmt (superseded by gofumpt)

It also removes task fmt as golangci-lint--fix is already doing the same job.