### PR TITLE
Remove Testify V2 notice on README as it wont happen

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,13 +475,3 @@ require.NoError(t, err)
 ```
 
 Please [contribute](./CONTRIBUTING.md) if you have ideas on how to make this better.
-
-## testify v2
-
-The second version of `testify` [promises](https://github.com/stretchr/testify/issues/1089) more "pleasant" API and
-makes some above checkers irrelevant.
-
-In this case, the possibility of supporting `v2` in the linter is not excluded.
-
-But at the moment it looks like we are [extremely far](https://github.com/stretchr/testify/pull/1109#issuecomment-1650619745)
-from `v2`. Related milestone [here](https://github.com/stretchr/testify/milestone/4).


### PR DESCRIPTION
# Background
As mentioned in this announcement [link](https://github.com/stretchr/testify/issues/1089#issuecomment-1812734472) from Testify maintainers

> So, as the current only active maintainer, I'm declaring that v2 will never happen. Or at least a v2 of the github.com/stretchr/testify module with such major breaking changes.

# Description
Remove Testify V2 notice on README as it won't happen
