### PR TITLE
helpers: isError: strict type comparison instead of implementing check

### DIFF
--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -42,6 +42,10 @@ func TestTestifyLint(t *testing.T) {
 			flags: map[string]string{"disable-all": "true", "enable": checkers.NewErrorIsAs().Name()},
 		},
 		{
+			dir:   "error-nil-issue95",
+			flags: map[string]string{"disable-all": "true", "enable": checkers.NewErrorNil().Name()},
+		},
+		{
 			dir: "expected-var-custom-pattern",
 			flags: map[string]string{
 				"disable-all":             "true",

--- a/analyzer/testdata/src/error-nil-issue95/mixed_struct_type_test.go
+++ b/analyzer/testdata/src/error-nil-issue95/mixed_struct_type_test.go
@@ -1,0 +1,33 @@
+package errornilissue95
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// APIResponse can be an error or not.
+type APIResponse struct {
+	Status   int
+	Data     string
+	ErrorMsg string
+}
+
+func (a APIResponse) Error() string {
+	return a.ErrorMsg
+}
+
+func Update(a string) (*APIResponse, error) {
+	if a == "a" {
+		return &APIResponse{Status: 200, Data: "fake"}, nil
+	}
+
+	return nil, &APIResponse{Status: 500, ErrorMsg: "Oops"}
+}
+
+func TestName(t *testing.T) {
+	resp, err := Update("b")
+	require.Error(t, err, new(*APIResponse))
+	assert.Nil(t, resp)
+}

--- a/internal/checkers/helpers_error.go
+++ b/internal/checkers/helpers_error.go
@@ -16,7 +16,7 @@ var (
 )
 
 func isError(pass *analysis.Pass, expr ast.Expr) bool {
-	return implements(pass, expr, errorObj)
+	return pass.TypesInfo.TypeOf(expr) == errorType
 }
 
 func isErrorsIsCall(pass *analysis.Pass, ce *ast.CallExpr) bool {


### PR DESCRIPTION
Closes https://github.com/Antonboom/testifylint/issues/95