### PR TITLE
Don't use 1.22 features

### DIFF
--- a/internal/checkers/printf/printf.go
+++ b/internal/checkers/printf/printf.go
@@ -215,7 +215,7 @@ func isFormatter(typ types.Type) bool {
 
 // isTypeParam reports whether t is a type parameter (or an alias of one).
 func isTypeParam(t types.Type) bool {
-	_, ok := types.Unalias(t).(*types.TypeParam)
+	_, ok := t.(*types.TypeParam)
 	return ok
 }
 
@@ -224,7 +224,7 @@ func isTypeParam(t types.Type) bool {
 // This function avoids allocating the concatenation of "pkg.Name",
 // which is important for the performance of syntax matching.
 func isNamedType(t types.Type, pkgPath string, names ...string) bool {
-	n, ok := types.Unalias(t).(*types.Named)
+	n, ok := t.(*types.Named)
 	if !ok {
 		return false
 	}


### PR DESCRIPTION
https://tip.golang.org/doc/go1.22

> The new [Alias](https://tip.golang.org/pkg/go/types#Alias) type represents type aliases. Previously, type aliases were not represented explicitly, so a reference to a type alias was equivalent to spelling out the aliased type, and the name of the alias was lost. The new representation retains the intermediate Alias. This enables improved error reporting (the name of a type alias can be reported), and allows for better handling of cyclic type declarations involving type aliases. In a future release, Alias types will also carry [type parameter information](https://tip.golang.org/issue/46477). The new function [Unalias](https://tip.golang.org/pkg/go/types#Unalias) returns the actual type denoted by an Alias type (or any other [Type](https://tip.golang.org/pkg/go/types#Type) for that matter).