### PR TITLE
Fix `formatter` when not importing assert package

### DIFF
--- a/internal/checkers/formatter.go
+++ b/internal/checkers/formatter.go
@@ -127,7 +127,12 @@ func isPrintfLikeCall(pass *analysis.Pass, call *CallMeta, sig *types.Signature)
 		return -1, false
 	}
 
-	fmtFn := analysisutil.ObjectOf(pass.Pkg, testify.AssertPkgPath, call.Fn.Name+"f")
+	pkgPath := testify.AssertPkgPath
+	if !call.IsAssert {
+		pkgPath = testify.RequirePkgPath
+	}
+
+	fmtFn := analysisutil.ObjectOf(pass.Pkg, pkgPath, call.Fn.Name+"f")
 	if fmtFn == nil {
 		// NOTE(a.telyshev): No formatted analogue of assertion.
 		return -1, false


### PR DESCRIPTION
Fixes https://github.com/Antonboom/testifylint/issues/170.

I tested manually that this fixes the issue on the example provided in the issue.

I wasn't able to add a test as it would require a whole new test suite (the bug was only when not importing the `assert` package), let me know if I should try to do that.