### PR TITLE
fix: false-positive useless-assert on Positive function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1123,14 +1123,12 @@ assert.Zero(t, false) // Any bool literal.
 assert.Negative(len(x))
 assert.Less(len(x), 0)
 assert.Greater(0, len(x))
-assert.Positive(len(x))
 assert.GreaterOrEqual(len(x), 0)
 assert.LessOrEqual(0, len(x))
 
 assert.Negative(uintVal)
 assert.Less(uintVal, 0)
 assert.Greater(0, uintVal)
-assert.Positive(uintVal)
 assert.GreaterOrEqual(uintVal, 0)
 assert.LessOrEqual(0, uintVal)
 ```

--- a/analyzer/testdata/src/checkers-default/useless-assert/useless_assert_test.go
+++ b/analyzer/testdata/src/checkers-default/useless-assert/useless_assert_test.go
@@ -364,13 +364,6 @@ func TestUselessAssertChecker(t *testing.T) {
 		assert.Greaterf(t, 0, len(x), "msg")                                                              // want "useless-assert: meaningless assertion"
 		assert.Greaterf(t, 0, len(x), "msg with arg %d", 42)                                              // want "useless-assert: meaningless assertion"
 		assert.Greaterf(t, 0, len(x), "msg with args %d %s", 42, "42")                                    // want "useless-assert: meaningless assertion"
-		assert.Positive(t, len(x))                                                                        // want "useless-assert: meaningless assertion"
-		assert.Positive(t, len(x), "msg")                                                                 // want "useless-assert: meaningless assertion"
-		assert.Positive(t, len(x), "msg with arg %d", 42)                                                 // want "useless-assert: meaningless assertion"
-		assert.Positive(t, len(x), "msg with args %d %s", 42, "42")                                       // want "useless-assert: meaningless assertion"
-		assert.Positivef(t, len(x), "msg")                                                                // want "useless-assert: meaningless assertion"
-		assert.Positivef(t, len(x), "msg with arg %d", 42)                                                // want "useless-assert: meaningless assertion"
-		assert.Positivef(t, len(x), "msg with args %d %s", 42, "42")                                      // want "useless-assert: meaningless assertion"
 		assert.GreaterOrEqual(t, len(x), 0)                                                               // want "useless-assert: meaningless assertion"
 		assert.GreaterOrEqual(t, len(x), 0, "msg")                                                        // want "useless-assert: meaningless assertion"
 		assert.GreaterOrEqual(t, len(x), 0, "msg with arg %d", 42)                                        // want "useless-assert: meaningless assertion"
@@ -406,13 +399,6 @@ func TestUselessAssertChecker(t *testing.T) {
 		assert.Greaterf(t, 0, uint(42), "msg")                                                            // want "useless-assert: meaningless assertion"
 		assert.Greaterf(t, 0, uint(42), "msg with arg %d", 42)                                            // want "useless-assert: meaningless assertion"
 		assert.Greaterf(t, 0, uint(42), "msg with args %d %s", 42, "42")                                  // want "useless-assert: meaningless assertion"
-		assert.Positive(t, uint(42))                                                                      // want "useless-assert: meaningless assertion"
-		assert.Positive(t, uint(42), "msg")                                                               // want "useless-assert: meaningless assertion"
-		assert.Positive(t, uint(42), "msg with arg %d", 42)                                               // want "useless-assert: meaningless assertion"
-		assert.Positive(t, uint(42), "msg with args %d %s", 42, "42")                                     // want "useless-assert: meaningless assertion"
-		assert.Positivef(t, uint(42), "msg")                                                              // want "useless-assert: meaningless assertion"
-		assert.Positivef(t, uint(42), "msg with arg %d", 42)                                              // want "useless-assert: meaningless assertion"
-		assert.Positivef(t, uint(42), "msg with args %d %s", 42, "42")                                    // want "useless-assert: meaningless assertion"
 		assert.GreaterOrEqual(t, uint(42), 0)                                                             // want "useless-assert: meaningless assertion"
 		assert.GreaterOrEqual(t, uint(42), 0, "msg")                                                      // want "useless-assert: meaningless assertion"
 		assert.GreaterOrEqual(t, uint(42), 0, "msg with arg %d", 42)                                      // want "useless-assert: meaningless assertion"
@@ -696,6 +682,34 @@ func TestUselessAssertChecker(t *testing.T) {
 		assert.Zerof(t, b, "msg")
 		assert.Zerof(t, b, "msg with arg %d", 42)
 		assert.Zerof(t, b, "msg with args %d %s", 42, "42")
+		assert.Positive(t, len(x))
+		assert.Positive(t, len(x), "msg")
+		assert.Positive(t, len(x), "msg with arg %d", 42)
+		assert.Positive(t, len(x), "msg with args %d %s", 42, "42")
+		assert.Positivef(t, len(x), "msg")
+		assert.Positivef(t, len(x), "msg with arg %d", 42)
+		assert.Positivef(t, len(x), "msg with args %d %s", 42, "42")
+		assert.Positive(t, uint(42))
+		assert.Positive(t, uint(42), "msg")
+		assert.Positive(t, uint(42), "msg with arg %d", 42)
+		assert.Positive(t, uint(42), "msg with args %d %s", 42, "42")
+		assert.Positivef(t, uint(42), "msg")
+		assert.Positivef(t, uint(42), "msg with arg %d", 42)
+		assert.Positivef(t, uint(42), "msg with args %d %s", 42, "42")
+		assert.Greater(t, len(x), 0)
+		assert.Greater(t, len(x), 0, "msg")
+		assert.Greater(t, len(x), 0, "msg with arg %d", 42)
+		assert.Greater(t, len(x), 0, "msg with args %d %s", 42, "42")
+		assert.Greaterf(t, len(x), 0, "msg")
+		assert.Greaterf(t, len(x), 0, "msg with arg %d", 42)
+		assert.Greaterf(t, len(x), 0, "msg with args %d %s", 42, "42")
+		assert.Greater(t, uint(42), 0)
+		assert.Greater(t, uint(42), 0, "msg")
+		assert.Greater(t, uint(42), 0, "msg with arg %d", 42)
+		assert.Greater(t, uint(42), 0, "msg with args %d %s", 42, "42")
+		assert.Greaterf(t, uint(42), 0, "msg")
+		assert.Greaterf(t, uint(42), 0, "msg with arg %d", 42)
+		assert.Greaterf(t, uint(42), 0, "msg with args %d %s", 42, "42")
 	}
 }
 

--- a/analyzer/testdata/src/debug/suite_method_signature_test.go
+++ b/analyzer/testdata/src/debug/suite_method_signature_test.go
@@ -18,8 +18,7 @@ func (s *BrokenSuite) SetupTest() {
 	var _ suite.TearDownSubTest
 }
 
-func (s *BrokenSuite) SetT() { // *BrokenSuite does not implement suite.TestingSuite (wrong type for method SetT)
-}
+//func (s *BrokenSuite) SetT() {} // *BrokenSuite does not implement suite.TestingSuite (wrong type for method SetT)
 
 func (s *BrokenSuite) TestTypo(_ *testing.T) { // value.go:424: test panicked: reflect: Call with too few input arguments
 	s.True(true)

--- a/analyzer/testdata/src/debug/useless_assert_test.go
+++ b/analyzer/testdata/src/debug/useless_assert_test.go
@@ -23,3 +23,7 @@ func TestUselessAsserts(t *testing.T) {
 	assert.Zero(t, "")
 	assert.Zero(t, nil)
 }
+
+func TestPositiveZero(t *testing.T) {
+	assert.Positive(t, uint64(0))
+}

--- a/internal/checkers/useless_assert.go
+++ b/internal/checkers/useless_assert.go
@@ -94,7 +94,13 @@ func (checker UselessAssert) Check(pass *analysis.Pass, call *CallMeta) *analysi
 	case "LessOrEqual", "Greater":
 		isMeaningless = (len(call.Args) >= 2) && isAnyZero(call.Args[0]) && canNotBeNegative(pass, call.Args[1])
 
-	case "Negative", "Positive":
+	case "Positive":
+		if len(call.Args) < 1 {
+			return nil
+		}
+		_, isMeaningless = isIntBasicLit(call.Args[0])
+
+	case "Negative":
 		if len(call.Args) < 1 {
 			return nil
 		}

--- a/internal/checkers/useless_assert.go
+++ b/internal/checkers/useless_assert.go
@@ -54,14 +54,12 @@ import (
 //	assert.Negative(len(x))
 //	assert.Less(len(x), 0)
 //	assert.Greater(0, len(x))
-//	assert.Positive(len(x))
 //	assert.GreaterOrEqual(len(x), 0)
 //	assert.LessOrEqual(0, len(x))
 //
 //	assert.Negative(uintVal)
 //	assert.Less(uintVal, 0)
 //	assert.Greater(0, uintVal)
-//	assert.Positive(uintVal)
 //	assert.GreaterOrEqual(uintVal, 0)
 //	assert.LessOrEqual(0, uintVal)
 type UselessAssert struct{}

--- a/internal/testgen/gen_useless_assert.go
+++ b/internal/testgen/gen_useless_assert.go
@@ -134,14 +134,12 @@ func (g UselessAssertTestsGenerator) TemplateData() any {
 			{Fn: "Negative", Argsf: "len(x)", ReportMsgf: defaultReport},
 			{Fn: "Less", Argsf: "len(x), 0", ReportMsgf: defaultReport},
 			{Fn: "Greater", Argsf: "0, len(x)", ReportMsgf: defaultReport},
-			{Fn: "Positive", Argsf: "len(x)", ReportMsgf: defaultReport},
 			{Fn: "GreaterOrEqual", Argsf: "len(x), 0", ReportMsgf: defaultReport},
 			{Fn: "LessOrEqual", Argsf: "0, len(x)", ReportMsgf: defaultReport},
 
 			{Fn: "Negative", Argsf: "uint(42)", ReportMsgf: defaultReport},
 			{Fn: "Less", Argsf: "uint(42), 0", ReportMsgf: defaultReport},
 			{Fn: "Greater", Argsf: "0, uint(42)", ReportMsgf: defaultReport},
-			{Fn: "Positive", Argsf: "uint(42)", ReportMsgf: defaultReport},
 			{Fn: "GreaterOrEqual", Argsf: "uint(42), 0", ReportMsgf: defaultReport},
 			{Fn: "LessOrEqual", Argsf: "0, uint(42)", ReportMsgf: defaultReport},
 		},
@@ -173,6 +171,12 @@ func (g UselessAssertTestsGenerator) TemplateData() any {
 			{Fn: "Zero", Argsf: "str"},
 			{Fn: "Zero", Argsf: "new(testCase)"},
 			{Fn: "Zero", Argsf: "b"},
+
+			// NOTE(a.telyshev): An unsigned value can be 0.
+			{Fn: "Positive", Argsf: "len(x)"},
+			{Fn: "Positive", Argsf: "uint(42)"},
+			{Fn: "Greater", Argsf: "len(x), 0"},
+			{Fn: "Greater", Argsf: "uint(42), 0"},
 		},
 	}
 }


### PR DESCRIPTION
It was reporting a false-positive `useless-assert` when calling the `Positive` function with `unsigned` integer types. It overlooked the fact that an unsigned integer might be zero, which is not positive. It is only useless to call `Negative` function with an `unsigned` integer.

See #235