### PR TITLE
chore: update golangci-lint to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   GO_VERSION: ^1.24
-  GOLANGCI_LINT_VERSION: v1.64.7
+  GOLANGCI_LINT_VERSION: v2.1.5
 
 permissions:
   contents: read
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v7
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --timeout=5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,101 +4,93 @@ run:
 issues:
   max-same-issues: 0
 
-  # revive should check comments for exported (and not internal) code.
-  include: [ EXC0012, EXC0013, EXC0014 ]
-
-  exclude-dirs:
-    - internal/checkers/printf # A patched fork of go vet's printf.
-
-  exclude-rules:
-    - path: "internal/testgen"
-      linters: [ "revive" ]
-      text: "exported"
-
-    - path: "internal/testgen"
-      linters: [ "forbidigo", "gochecknoinits", "prealloc" ] # Internal test generation tool.
-
-    - path: "internal"
-      linters: [ "revive" ]
-      text: "exported (method|const)"
-
-    - path: "_test\\.go"
-      linters: [ "lll" ]
-
-    - source: ' // want '
-      linters: [ "lll" ]
-
-linters-settings:
-  depguard:
-    rules:
-      analysisutil:
-        files: [ "**/internal/analysisutil/*.go" ]
-        deny:
-          - pkg: golang.org/x/tools/go/analysis
-            desc: Please, implement helpers without usage of x/tools
-
-  forbidigo:
-    forbid:
-      - p: panic
-        msg: Please, don't panic
-
-      - p: types\.ExprString
-        msg: Please, use analysisutil.NodeBytes/NodeString instead
-
-  gocritic:
-    disabled-checks:
-      - singleCaseSwitch
-
-  gosec:
-    excludes:
-      - "G306" # Expect WriteFile permissions to be 0600 or less
-
-  govet:
-    enable-all: true
-    disable:
-      - fieldalignment
-
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/Antonboom/testifylint)
-
-  lll:
-    line-length: 130
-
-  revive:
-    rules:
-      - name: blank-imports
-      - name: context-as-argument
-      - name: context-keys-type
-      - name: dot-imports
-      - name: early-return
-        arguments:
-          - "preserveScope"
-      - name: empty-block
-      - name: error-naming
-      - name: error-return
-      - name: error-strings
-      - name: errorf
-      - name: identical-branches
-      - name: if-return
-      - name: increment-decrement
-      - name: indent-error-flow
-      - name: range
-      - name: receiver-naming
-      - name: redefines-builtin-id
-      - name: superfluous-else
-      - name: time-naming
-      - name: unexported-return
-      - name: unreachable-code
-      - name: unused-parameter
-      - name: useless-break
-      - name: var-declaration
-      - name: var-naming
-
 linters:
-  disable-all: true
+  exclusions:
+    paths:
+      - internal/checkers/printf # A patched fork of go vet's printf.
+
+    rules:
+      - path: "internal/testgen"
+        linters: [ "forbidigo", "gochecknoinits", "prealloc" ] # Internal test generation tool.
+
+      - path: "_test\\.go"
+        linters: [ "lll" ]
+
+      - source: ' // want '
+        linters: [ "lll" ]
+
+    presets:
+      - common-false-positives
+      - legacy
+      - std-error-handling
+
+    warn-unused: true
+
+  settings:
+    depguard:
+      rules:
+        analysisutil:
+          files: [ "**/internal/analysisutil/*.go" ]
+          deny:
+            - pkg: golang.org/x/tools/go/analysis
+              desc: Please, implement helpers without usage of x/tools
+
+    forbidigo:
+      forbid:
+        - pattern: panic
+          msg: Please, don't panic
+
+        - pattern: types\.ExprString
+          msg: Please, use analysisutil.NodeBytes/NodeString instead
+
+    gocritic:
+      disabled-checks:
+        - singleCaseSwitch
+
+    gosec:
+      excludes:
+        - "G306" # Expect WriteFile permissions to be 0600 or less
+
+    govet:
+      enable-all: true
+      disable:
+        - fieldalignment
+
+    lll:
+      line-length: 130
+
+    revive:
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+        - name: early-return
+          arguments:
+            - "preserveScope"
+        - name: empty-block
+        - name: error-naming
+        - name: error-return
+        - name: error-strings
+        - name: errorf
+        - name: identical-branches
+        - name: if-return
+        - name: increment-decrement
+        - name: indent-error-flow
+        - name: range
+        - name: receiver-naming
+        - name: redefines-builtin-id
+        - name: superfluous-else
+        - name: time-naming
+        - name: unexported-return
+        - name: unreachable-code
+        - name: unused-parameter
+        - name: useless-break
+        - name: var-declaration
+        - name: var-naming
+
+  default: none
+
   enable:
     - asasalint
     - asciicheck
@@ -111,16 +103,13 @@ linters:
     - exhaustive
     - exptostd
     - forbidigo
-    - gci
     - gocheckcompilerdirectives
     - gochecknoinits
     - gocritic
     - godot
     - godox
-    - gofumpt
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - intrange
@@ -129,9 +118,9 @@ linters:
     - mirror
     - misspell
     - nakedret
+    - nestif
     - nilerr
     - nilnesserr
-    - nestif
     - nolintlint
     - perfsprint
     - prealloc
@@ -139,7 +128,6 @@ linters:
     - reassign
     - revive
     - staticcheck
-    - stylecheck
     - testableexamples
     - testpackage
     - thelper
@@ -150,3 +138,20 @@ linters:
     - usetesting
     - wastedassign
     - whitespace
+
+formatters:
+  enable:
+    - gci
+    - gofumpt
+
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/Antonboom/testifylint)
+
+output:
+  show-stats: false
+
+version: "2"

--- a/internal/checkers/call_meta.go
+++ b/internal/checkers/call_meta.go
@@ -93,7 +93,7 @@ func NewCallMeta(pass *analysis.Pass, ce *ast.CallExpr) *CallMeta {
 
 	isAssert := analysisutil.IsPkg(initiatorPkg, testify.AssertPkgName, testify.AssertPkgPath)
 	isRequire := analysisutil.IsPkg(initiatorPkg, testify.RequirePkgName, testify.RequirePkgPath)
-	if !(isAssert || isRequire) {
+	if !isAssert && !isRequire {
 		return nil
 	}
 


### PR DESCRIPTION
#### Description

Update golangci-lint to v2 and golangci-lint-action to v7

Update golangci-lint configuration to fit v2 format, including removing unapplied exclusion, thanks to warn-unused capability.

Fixes a newly discovered issue