### PR TITLE
feat: Add TimeEqual checker to enforce proper time comparisons

### DIFF
--- a/internal/checkers/checkers_registry.go
+++ b/internal/checkers/checkers_registry.go
@@ -25,6 +25,7 @@ var registry = checkersRegistry{
 	{factory: asCheckerFactory(NewSuiteDontUsePkg), enabledByDefault: true},
 	{factory: asCheckerFactory(NewUselessAssert), enabledByDefault: true},
 	{factory: asCheckerFactory(NewFormatter), enabledByDefault: true},
+	{factory: asCheckerFactory(NewTimeEqual), enabledByDefault: true},
 	// Advanced checkers.
 	{factory: asCheckerFactory(NewBlankImport), enabledByDefault: true},
 	{factory: asCheckerFactory(NewGoRequire), enabledByDefault: true},

--- a/internal/checkers/time_equal.go
+++ b/internal/checkers/time_equal.go
@@ -1,0 +1,97 @@
+package checkers
+
+import (
+	"fmt"
+	"go/types"
+
+	"github.com/Antonboom/testifylint/internal/analysisutil"
+	"golang.org/x/tools/go/analysis"
+)
+
+// TimeEqual detects situations like
+//
+//	assert.Equal(t, timeA, timeB)
+//	assert.NotEqual(t, timeA, timeB)
+//
+// and requires
+//
+//	assert.True(t, timeA.Equal(timeB))
+//	assert.False(t, timeA.Equal(timeB))
+
+type TimeEqual struct{}
+
+func NewTimeEqual() TimeEqual {
+	return TimeEqual{}
+}
+
+func (TimeEqual) Name() string {
+	return "time-compare"
+}
+
+func (checker TimeEqual) Check(pass *analysis.Pass, call *CallMeta) *analysis.Diagnostic {
+	assrn := call.Fn.NameFTrimmed
+
+	var isEq bool
+	switch assrn {
+	default:
+		return nil
+	case "Equal":
+		isEq = true
+	case "NotEqual":
+		isEq = false
+	}
+
+	if len(call.Args) < 2 {
+		return nil
+	}
+
+	first, second := call.Args[0], call.Args[1]
+
+	ft, st := pass.TypesInfo.TypeOf(first), pass.TypesInfo.TypeOf(second)
+
+	if !isTimeType(ft) || !isTimeType(st) {
+		return nil
+	}
+
+	if isEq {
+		return newDiagnostic(
+			checker.Name(),
+			call,
+			fmt.Sprintf("replace %s.Equal with %s.True passing time.Equal", call.SelectorXStr, call.SelectorXStr),
+			newSuggestedFuncReplacement(
+				call,
+				"True",
+				analysis.TextEdit{
+					Pos:     first.Pos(),
+					End:     second.End(),
+					NewText: []byte(analysisutil.NodeString(pass.Fset, first) + ".Equal(" + analysisutil.NodeString(pass.Fset, second) + ")"),
+				},
+			),
+		)
+	} else {
+		return newDiagnostic(
+			checker.Name(),
+			call,
+			fmt.Sprintf("replace %s.NotEqual with %s.False passing time.Equal", call.SelectorXStr, call.SelectorXStr),
+			newSuggestedFuncReplacement(
+				call,
+				"False",
+				analysis.TextEdit{
+					Pos:     first.Pos(),
+					End:     second.End(),
+					NewText: []byte(analysisutil.NodeString(pass.Fset, first) + ".Equal(" + analysisutil.NodeString(pass.Fset, second) + ")"),
+				},
+			),
+		)
+	}
+}
+
+func isTimeType(typ types.Type) bool {
+	n, ok := typ.(*types.Named)
+	if !ok {
+		return false
+	}
+
+	typeName := n.Obj()
+	return typeName != nil && typeName.Pkg() != nil && typeName.Pkg().Path() == "time" && typeName.Name() == "Time"
+}


### PR DESCRIPTION
fix #242
closes https://github.com/Antonboom/testifylint/issues/60

@Antonboom 

If you're okay with the new checker, I'll add the corresponding unit tests and refactor the diagnostic messages and fixes.