### PR TITLE
Migrate to v2 of golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ on:
     branches: [ master ]
 
 env:
-  GO_VERSION: ^1.24
-  GOLANGCI_LINT_VERSION: v1.64.7
+  GO_VERSION: ^1.25
+  GOLANGCI_LINT_VERSION: v2.4.0
 
 permissions:
   contents: read
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v8
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --timeout=5m

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,6 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
       - run: go test -coverpkg=./analyzer,./internal/analysisutil,./internal/checkers,./internal/config -coverprofile=coverage.out ./...
-        env:
-          GOEXPERIMENT: nocoverageredesign # https://github.com/golang/go/issues/65653#issuecomment-1955872134
       - uses: shogo82148/actions-goveralls@v1
         with:
           path-to-profile: coverage.out

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,104 +1,30 @@
+version: "2"
+
 run:
   tests: true
 
 issues:
   max-same-issues: 0
 
-  # revive should check comments for exported (and not internal) code.
-  include: [ EXC0012, EXC0013, EXC0014 ]
+formatters:
+  enable:
+    - gci
+    - gofumpt
 
-  exclude-dirs:
-    - internal/checkers/printf # A patched fork of go vet's printf.
+  settings:
+    gci:
+      sections:
+        - standard # A standard section: captures all standard packages.
+        - default  # Default section: contains all imports that could not be matched to another section type.
+        - prefix(github.com/Antonboom/testifylint)
 
-  exclude-rules:
-    - path: "internal/testgen"
-      linters: [ "revive" ]
-      text: "exported"
-
-    - path: "internal/testgen"
-      linters: [ "forbidigo", "gochecknoinits", "prealloc" ] # Internal test generation tool.
-
-    - path: "internal"
-      linters: [ "revive" ]
-      text: "exported (method|const)"
-
-    - path: "_test\\.go"
-      linters: [ "lll" ]
-
-    - source: ' // want '
-      linters: [ "lll" ]
-
-linters-settings:
-  depguard:
-    rules:
-      analysisutil:
-        files: [ "**/internal/analysisutil/*.go" ]
-        deny:
-          - pkg: golang.org/x/tools/go/analysis
-            desc: Please, implement helpers without usage of x/tools
-
-  forbidigo:
-    forbid:
-      - p: panic
-        msg: Please, don't panic
-
-      - p: types\.ExprString
-        msg: Please, use analysisutil.NodeBytes/NodeString instead
-
-  gocritic:
-    disabled-checks:
-      - singleCaseSwitch
-
-  gosec:
-    excludes:
-      - "G306" # Expect WriteFile permissions to be 0600 or less
-
-  govet:
-    enable-all: true
-    disable:
-      - fieldalignment
-
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/Antonboom/testifylint)
-
-  lll:
-    line-length: 130
-
-  revive:
-    rules:
-      - name: blank-imports
-      - name: context-as-argument
-      - name: context-keys-type
-      - name: dot-imports
-      - name: early-return
-        arguments:
-          - "preserveScope"
-      - name: empty-block
-      - name: error-naming
-      - name: error-return
-      - name: error-strings
-      - name: errorf
-      - name: identical-branches
-      - name: if-return
-      - name: increment-decrement
-      - name: indent-error-flow
-      - name: range
-      - name: receiver-naming
-      - name: redefines-builtin-id
-      - name: superfluous-else
-      - name: time-naming
-      - name: unexported-return
-      - name: unreachable-code
-      - name: unused-parameter
-      - name: useless-break
-      - name: var-declaration
-      - name: var-naming
+  exclusions:
+    generated: lax
+    paths:
+      - internal/checkers/printf # A patched fork of go vet's printf.
 
 linters:
-  disable-all: true
+  default: none
   enable:
     - asasalint
     - asciicheck
@@ -111,17 +37,15 @@ linters:
     - exhaustive
     - exptostd
     - forbidigo
-    - gci
     - gocheckcompilerdirectives
     - gochecknoinits
     - gocritic
     - godot
     - godox
-    - gofumpt
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
+    - importas
     - ineffassign
     - intrange
     - lll
@@ -129,9 +53,9 @@ linters:
     - mirror
     - misspell
     - nakedret
+    - nestif
     - nilerr
     - nilnesserr
-    - nestif
     - nolintlint
     - perfsprint
     - prealloc
@@ -139,7 +63,6 @@ linters:
     - reassign
     - revive
     - staticcheck
-    - stylecheck
     - testableexamples
     - testpackage
     - thelper
@@ -150,3 +73,95 @@ linters:
     - usetesting
     - wastedassign
     - whitespace
+
+  exclusions:
+    generated: lax
+    presets:
+      - common-false-positives
+      - legacy
+      - std-error-handling
+
+    rules:
+      - path: "internal/testgen"
+        linters: [ "revive" ]
+        text: "exported"
+
+      - path: "internal/testgen"
+        linters: [ "forbidigo", "gochecknoinits", "prealloc" ] # Internal test generation tool.
+
+      - path: "internal"
+        linters: [ "revive" ]
+        text: "exported (method|const)"
+
+      - path: "_test\\.go"
+        linters: [ "lll" ]
+
+      - source: ' // want '
+        linters: [ "lll" ]
+
+    paths:
+      - internal/checkers/printf # A patched fork of go vet's printf.
+
+  settings:
+    depguard:
+      rules:
+        analysisutil:
+          files:
+            - '**/internal/analysisutil/*.go'
+          deny:
+            - pkg: golang.org/x/tools/go/analysis
+              desc: Please, implement helpers without usage of x/tools
+
+    forbidigo:
+      forbid:
+        - pattern: panic
+          msg: Please, don't panic
+
+        - pattern: types\.ExprString
+          msg: Please, use analysisutil.NodeBytes/NodeString instead
+
+    gocritic:
+      disabled-checks:
+        - singleCaseSwitch
+
+    gosec:
+      excludes:
+        - G306 # Expect WriteFile permissions to be 0600 or less.
+
+    govet:
+      disable:
+        - fieldalignment
+      enable-all: true
+
+    lll:
+      line-length: 130
+
+    revive:
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+        - name: early-return
+          arguments:
+            - preserveScope
+        - name: empty-block
+        - name: error-naming
+        - name: error-return
+        - name: error-strings
+        - name: errorf
+        - name: identical-branches
+        - name: if-return
+        - name: increment-decrement
+        - name: indent-error-flow
+        - name: range
+        - name: receiver-naming
+        - name: redefines-builtin-id
+        - name: superfluous-else
+        - name: time-naming
+        - name: unexported-return
+        - name: unreachable-code
+        - name: unused-parameter
+        - name: useless-break
+        - name: var-declaration
+        - name: var-naming

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,10 @@
 # Contribution guideline
 
-### 1) Install developer tools
+### 1) Install `task`
 
 ```bash
 # https://taskfile.dev/installation/
 $ go install github.com/go-task/task/v3/cmd/task@latest
-$ task tools:install
-Install dev tools...
 ```
 
 ### 2) Create a checker skeleton in `internal/checkers/{checker_name}.go`

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -17,12 +17,6 @@ tasks:
       - task: fmt
       - task: lint
       - task: test
-      - task: install
-
-  tools:install:
-    - echo "Install dev tools..."
-    - go install github.com/daixiang0/gci@latest
-    - go install mvdan.cc/gofumpt@latest
 
   tidy:
     cmds:
@@ -32,8 +26,7 @@ tasks:
   fmt:
     cmds:
       - echo "Fmt..."
-      - gofumpt -w .
-      - gci write -s standard -s default -s "Prefix(github.com/Antonboom/testifylint)" . 2> /dev/null
+      - golangci-lint fmt -v ./...
 
   lint:
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -46,8 +46,6 @@ tasks:
       - go test -count 1 -run TestTestifyLint/{{.CLI_ARGS}} ./analyzer
 
   test:coverage:
-    env:
-      GOEXPERIMENT: nocoverageredesign # https://github.com/golang/go/issues/65653#issuecomment-1955872134
     cmds:
       - echo "Test with coverage..."
       - go test -coverpkg={{ .COVERED_PKGS | trim | splitLines | join "," }} -coverprofile=coverage.out ./...

--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,11 @@ module github.com/Antonboom/testifylint
 
 go 1.23.0
 
-toolchain go1.24.1
+toolchain go1.25.0
 
-require golang.org/x/tools v0.32.0
+require golang.org/x/tools v0.36.0
 
 require (
-	golang.org/x/mod v0.24.0 // indirect
-	golang.org/x/sync v0.13.0 // indirect
+	golang.org/x/mod v0.27.0 // indirect
+	golang.org/x/sync v0.16.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-golang.org/x/mod v0.24.0 h1:ZfthKaKaT4NrhGVZHO1/WDTwGES4De8KtWO0SIbNJMU=
-golang.org/x/mod v0.24.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=
-golang.org/x/sync v0.13.0 h1:AauUjRAJ9OSnvULf/ARrrVywoJDy0YS2AwQ98I37610=
-golang.org/x/sync v0.13.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
-golang.org/x/tools v0.32.0 h1:Q7N1vhpkQv7ybVzLFtTjvQya2ewbwNDZzUgfXGqtMWU=
-golang.org/x/tools v0.32.0/go.mod h1:ZxrU41P/wAbZD8EDa6dDCa6XfpkhJ7HFMjHJXfBDu8s=
+golang.org/x/mod v0.27.0 h1:kb+q2PyFnEADO2IEF935ehFUXlWiNjJWtRNgBLSfbxQ=
+golang.org/x/mod v0.27.0/go.mod h1:rWI627Fq0DEoudcK+MBkNkCe0EetEaDSwJJkCcjpazc=
+golang.org/x/sync v0.16.0 h1:ycBJEhp9p4vXvUZNszeOq0kGTPghopOL8q0fq3vstxw=
+golang.org/x/sync v0.16.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+golang.org/x/tools v0.36.0 h1:kWS0uv/zsvHEle1LbV5LE8QujrxB3wfQyxHfhOk0Qkg=
+golang.org/x/tools v0.36.0/go.mod h1:WBDiHKJK8YgLHlcQPYQzNCkUxUypCaa5ZegCVutKm+s=

--- a/internal/checkers/call_meta.go
+++ b/internal/checkers/call_meta.go
@@ -93,7 +93,7 @@ func NewCallMeta(pass *analysis.Pass, ce *ast.CallExpr) *CallMeta {
 
 	isAssert := analysisutil.IsPkg(initiatorPkg, testify.AssertPkgName, testify.AssertPkgPath)
 	isRequire := analysisutil.IsPkg(initiatorPkg, testify.RequirePkgName, testify.RequirePkgPath)
-	if !(isAssert || isRequire) {
+	if !isAssert && !isRequire {
 		return nil
 	}
 


### PR DESCRIPTION
closes https://github.com/Antonboom/testifylint/pull/254
closes https://github.com/Antonboom/testifylint/pull/245