### PR TITLE
regexp: warn when rx argument is not string or *regexp.Regexp

### DIFF
--- a/analyzer/testdata/src/checkers-default/regexp/regexp_test.go
+++ b/analyzer/testdata/src/checkers-default/regexp/regexp_test.go
@@ -9,15 +9,74 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type myDefinedString string
+
+type myStrAlias = string
+
+type myRegexpStructAlias = regexp.Regexp
+
+type testStringer struct{}
+
+func (testStringer) String() string { return "42" }
+
+// myRxAlias is a type alias for *regexp.Regexp used to verify that alias types are accepted.
+type myRxAlias = *regexp.Regexp
+
+// assertRegexpGeneric demonstrates that a type parameter is accepted conservatively.
+// This differs from aliases such as myStrAlias or myRxAlias, which are handled separately.
+func assertRegexpGeneric[T ~string](t *testing.T, rx T, str string) {
+	assert.Regexp(t, rx, str)
+	assert.NotRegexp(t, rx, str)
+}
+
 func TestRegexpChecker(t *testing.T) {
 	var out string
+	compiledRegexp := regexp.MustCompile(`\w+`)
+	var rxRegexpStructAlias *myRegexpStructAlias = regexp.MustCompile(`\w+`)
+	var rxAlias myRxAlias = regexp.MustCompile(`\w+`)
 
-	// Invalid.
+	// Invalid: regexp.MustCompile usage.
 	{
 		assert.Regexp(t, regexp.MustCompile(`\[.*\] DEBUG \(.*TestNew.*\): message`), out)                                   // want "regexp: remove unnecessary regexp\\.MustCompile"
 		assert.Regexpf(t, regexp.MustCompile(`\[.*\] DEBUG \(.*TestNew.*\): message`), out, "msg with args %d %s", 42, "42") // want "regexp: remove unnecessary regexp\\.MustCompile"
 		assert.NotRegexp(t, regexp.MustCompile(`\[.*\] TRACE message`), out)                                                 // want "regexp: remove unnecessary regexp\\.MustCompile"
 		assert.NotRegexpf(t, regexp.MustCompile(`\[.*\] TRACE message`), out, "msg with args %d %s", 42, "42")               // want "regexp: remove unnecessary regexp\\.MustCompile"
+	}
+
+	// Invalid: non-string, non-*regexp.Regexp first argument.
+	{
+		assert.Regexp(t, []byte(`\w+`), out)                                               // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.Regexpf(t, []byte(`\w+`), out, "msg with args %d %s", 42, "42")             // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexp(t, []byte(`\w+`), out)                                            // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexpf(t, []byte(`\w+`), out, "msg with args %d %s", 42, "42")          // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.Regexp(t, myDefinedString(`\w+`), out)                                      // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.Regexpf(t, myDefinedString(`\w+`), out, "msg with args %d %s", 42, "42")    // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexp(t, myDefinedString(`\w+`), out)                                   // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexpf(t, myDefinedString(`\w+`), out, "msg with args %d %s", 42, "42") // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.Regexp(t, rxRegexpStructAlias, out)                                         // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.Regexpf(t, rxRegexpStructAlias, out, "msg with args %d %s", 42, "42")       // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexp(t, rxRegexpStructAlias, out)                                      // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexpf(t, rxRegexpStructAlias, out, "msg with args %d %s", 42, "42")    // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.Regexp(t, 42, out)                                                          // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.Regexpf(t, 42, out, "msg with args %d %s", 42, "42")                        // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexp(t, 42, out)                                                       // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexpf(t, 42, out, "msg with args %d %s", 42, "42")                     // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.Regexp(t, int8(42), out)                                                    // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.Regexpf(t, int8(42), out, "msg with args %d %s", 42, "42")                  // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexp(t, int8(42), out)                                                 // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexpf(t, int8(42), out, "msg with args %d %s", 42, "42")               // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.Regexp(t, uint8(42), out)                                                   // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.Regexpf(t, uint8(42), out, "msg with args %d %s", 42, "42")                 // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexp(t, uint8(42), out)                                                // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexpf(t, uint8(42), out, "msg with args %d %s", 42, "42")              // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.Regexp(t, 42.0, out)                                                        // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.Regexpf(t, 42.0, out, "msg with args %d %s", 42, "42")                      // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexp(t, 42.0, out)                                                     // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexpf(t, 42.0, out, "msg with args %d %s", 42, "42")                   // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.Regexp(t, testStringer{}, out)                                              // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.Regexpf(t, testStringer{}, out, "msg with args %d %s", 42, "42")            // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexp(t, testStringer{}, out)                                           // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexpf(t, testStringer{}, out, "msg with args %d %s", 42, "42")         // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
 	}
 
 	// Valid.
@@ -26,5 +85,17 @@ func TestRegexpChecker(t *testing.T) {
 		assert.Regexpf(t, `\[.*\] DEBUG \(.*TestNew.*\): message`, out, "msg with args %d %s", 42, "42")
 		assert.NotRegexp(t, `\[.*\] TRACE message`, out)
 		assert.NotRegexpf(t, `\[.*\] TRACE message`, out, "msg with args %d %s", 42, "42")
+		assert.Regexp(t, myStrAlias(`\w+`), out)
+		assert.Regexpf(t, myStrAlias(`\w+`), out, "msg with args %d %s", 42, "42")
+		assert.NotRegexp(t, myStrAlias(`\w+`), out)
+		assert.NotRegexpf(t, myStrAlias(`\w+`), out, "msg with args %d %s", 42, "42")
+		assert.Regexp(t, compiledRegexp, out)
+		assert.Regexpf(t, compiledRegexp, out, "msg with args %d %s", 42, "42")
+		assert.NotRegexp(t, compiledRegexp, out)
+		assert.NotRegexpf(t, compiledRegexp, out, "msg with args %d %s", 42, "42")
+		assert.Regexp(t, rxAlias, out)
+		assert.Regexpf(t, rxAlias, out, "msg with args %d %s", 42, "42")
+		assert.NotRegexp(t, rxAlias, out)
+		assert.NotRegexpf(t, rxAlias, out, "msg with args %d %s", 42, "42")
 	}
 }

--- a/analyzer/testdata/src/checkers-default/regexp/regexp_test.go
+++ b/analyzer/testdata/src/checkers-default/regexp/regexp_test.go
@@ -9,15 +9,34 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// myRxAlias is a type alias for *regexp.Regexp used to verify that alias types are accepted.
+type myRxAlias = *regexp.Regexp
+
+// assertRegexpGeneric demonstrates that type parameters are accepted conservatively.
+func assertRegexpGeneric[T ~string](t *testing.T, rx T, str string) {
+	assert.Regexp(t, rx, str)
+	assert.NotRegexp(t, rx, str)
+}
+
 func TestRegexpChecker(t *testing.T) {
 	var out string
+	compiledRegexp := regexp.MustCompile(`\w+`)
+	var rxAlias myRxAlias = regexp.MustCompile(`\w+`)
 
-	// Invalid.
+	// Invalid: regexp.MustCompile usage.
 	{
 		assert.Regexp(t, regexp.MustCompile(`\[.*\] DEBUG \(.*TestNew.*\): message`), out)                                   // want "regexp: remove unnecessary regexp\\.MustCompile"
 		assert.Regexpf(t, regexp.MustCompile(`\[.*\] DEBUG \(.*TestNew.*\): message`), out, "msg with args %d %s", 42, "42") // want "regexp: remove unnecessary regexp\\.MustCompile"
 		assert.NotRegexp(t, regexp.MustCompile(`\[.*\] TRACE message`), out)                                                 // want "regexp: remove unnecessary regexp\\.MustCompile"
 		assert.NotRegexpf(t, regexp.MustCompile(`\[.*\] TRACE message`), out, "msg with args %d %s", 42, "42")               // want "regexp: remove unnecessary regexp\\.MustCompile"
+	}
+
+	// Invalid: non-string, non-*regexp.Regexp first argument.
+	{
+		assert.Regexp(t, []byte(`\w+`), out)                                      // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.Regexpf(t, []byte(`\w+`), out, "msg with args %d %s", 42, "42")    // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexp(t, []byte(`\w+`), out)                                   // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexpf(t, []byte(`\w+`), out, "msg with args %d %s", 42, "42") // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
 	}
 
 	// Valid.
@@ -26,5 +45,13 @@ func TestRegexpChecker(t *testing.T) {
 		assert.Regexpf(t, `\[.*\] DEBUG \(.*TestNew.*\): message`, out, "msg with args %d %s", 42, "42")
 		assert.NotRegexp(t, `\[.*\] TRACE message`, out)
 		assert.NotRegexpf(t, `\[.*\] TRACE message`, out, "msg with args %d %s", 42, "42")
+		assert.Regexp(t, compiledRegexp, out)
+		assert.Regexpf(t, compiledRegexp, out, "msg with args %d %s", 42, "42")
+		assert.NotRegexp(t, compiledRegexp, out)
+		assert.NotRegexpf(t, compiledRegexp, out, "msg with args %d %s", 42, "42")
+		assert.Regexp(t, rxAlias, out)
+		assert.Regexpf(t, rxAlias, out, "msg with args %d %s", 42, "42")
+		assert.NotRegexp(t, rxAlias, out)
+		assert.NotRegexpf(t, rxAlias, out, "msg with args %d %s", 42, "42")
 	}
 }

--- a/analyzer/testdata/src/checkers-default/regexp/regexp_test.go.golden
+++ b/analyzer/testdata/src/checkers-default/regexp/regexp_test.go.golden
@@ -9,15 +9,34 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// myRxAlias is a type alias for *regexp.Regexp used to verify that alias types are accepted.
+type myRxAlias = *regexp.Regexp
+
+// assertRegexpGeneric demonstrates that type parameters are accepted conservatively.
+func assertRegexpGeneric[T ~string](t *testing.T, rx T, str string) {
+	assert.Regexp(t, rx, str)
+	assert.NotRegexp(t, rx, str)
+}
+
 func TestRegexpChecker(t *testing.T) {
 	var out string
+	compiledRegexp := regexp.MustCompile(`\w+`)
+	var rxAlias myRxAlias = regexp.MustCompile(`\w+`)
 
-	// Invalid.
+	// Invalid: regexp.MustCompile usage.
 	{
 		assert.Regexp(t, `\[.*\] DEBUG \(.*TestNew.*\): message`, out)                                   // want "regexp: remove unnecessary regexp\\.MustCompile"
 		assert.Regexpf(t, `\[.*\] DEBUG \(.*TestNew.*\): message`, out, "msg with args %d %s", 42, "42") // want "regexp: remove unnecessary regexp\\.MustCompile"
 		assert.NotRegexp(t, `\[.*\] TRACE message`, out)                                                 // want "regexp: remove unnecessary regexp\\.MustCompile"
 		assert.NotRegexpf(t, `\[.*\] TRACE message`, out, "msg with args %d %s", 42, "42")               // want "regexp: remove unnecessary regexp\\.MustCompile"
+	}
+
+	// Invalid: non-string, non-*regexp.Regexp first argument.
+	{
+		assert.Regexp(t, []byte(`\w+`), out)                                      // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.Regexpf(t, []byte(`\w+`), out, "msg with args %d %s", 42, "42")    // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexp(t, []byte(`\w+`), out)                                   // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexpf(t, []byte(`\w+`), out, "msg with args %d %s", 42, "42") // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
 	}
 
 	// Valid.
@@ -26,5 +45,13 @@ func TestRegexpChecker(t *testing.T) {
 		assert.Regexpf(t, `\[.*\] DEBUG \(.*TestNew.*\): message`, out, "msg with args %d %s", 42, "42")
 		assert.NotRegexp(t, `\[.*\] TRACE message`, out)
 		assert.NotRegexpf(t, `\[.*\] TRACE message`, out, "msg with args %d %s", 42, "42")
+		assert.Regexp(t, compiledRegexp, out)
+		assert.Regexpf(t, compiledRegexp, out, "msg with args %d %s", 42, "42")
+		assert.NotRegexp(t, compiledRegexp, out)
+		assert.NotRegexpf(t, compiledRegexp, out, "msg with args %d %s", 42, "42")
+		assert.Regexp(t, rxAlias, out)
+		assert.Regexpf(t, rxAlias, out, "msg with args %d %s", 42, "42")
+		assert.NotRegexp(t, rxAlias, out)
+		assert.NotRegexpf(t, rxAlias, out, "msg with args %d %s", 42, "42")
 	}
 }

--- a/analyzer/testdata/src/checkers-default/regexp/regexp_test.go.golden
+++ b/analyzer/testdata/src/checkers-default/regexp/regexp_test.go.golden
@@ -9,15 +9,74 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type myDefinedString string
+
+type myStrAlias = string
+
+type myRegexpStructAlias = regexp.Regexp
+
+type testStringer struct{}
+
+func (testStringer) String() string { return "42" }
+
+// myRxAlias is a type alias for *regexp.Regexp used to verify that alias types are accepted.
+type myRxAlias = *regexp.Regexp
+
+// assertRegexpGeneric demonstrates that a type parameter is accepted conservatively.
+// This differs from aliases such as myStrAlias or myRxAlias, which are handled separately.
+func assertRegexpGeneric[T ~string](t *testing.T, rx T, str string) {
+	assert.Regexp(t, rx, str)
+	assert.NotRegexp(t, rx, str)
+}
+
 func TestRegexpChecker(t *testing.T) {
 	var out string
+	compiledRegexp := regexp.MustCompile(`\w+`)
+	var rxRegexpStructAlias *myRegexpStructAlias = regexp.MustCompile(`\w+`)
+	var rxAlias myRxAlias = regexp.MustCompile(`\w+`)
 
-	// Invalid.
+	// Invalid: regexp.MustCompile usage.
 	{
 		assert.Regexp(t, `\[.*\] DEBUG \(.*TestNew.*\): message`, out)                                   // want "regexp: remove unnecessary regexp\\.MustCompile"
 		assert.Regexpf(t, `\[.*\] DEBUG \(.*TestNew.*\): message`, out, "msg with args %d %s", 42, "42") // want "regexp: remove unnecessary regexp\\.MustCompile"
 		assert.NotRegexp(t, `\[.*\] TRACE message`, out)                                                 // want "regexp: remove unnecessary regexp\\.MustCompile"
 		assert.NotRegexpf(t, `\[.*\] TRACE message`, out, "msg with args %d %s", 42, "42")               // want "regexp: remove unnecessary regexp\\.MustCompile"
+	}
+
+	// Invalid: non-string, non-*regexp.Regexp first argument.
+	{
+		assert.Regexp(t, []byte(`\w+`), out)                                               // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.Regexpf(t, []byte(`\w+`), out, "msg with args %d %s", 42, "42")             // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexp(t, []byte(`\w+`), out)                                            // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexpf(t, []byte(`\w+`), out, "msg with args %d %s", 42, "42")          // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.Regexp(t, myDefinedString(`\w+`), out)                                      // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.Regexpf(t, myDefinedString(`\w+`), out, "msg with args %d %s", 42, "42")    // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexp(t, myDefinedString(`\w+`), out)                                   // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexpf(t, myDefinedString(`\w+`), out, "msg with args %d %s", 42, "42") // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.Regexp(t, rxRegexpStructAlias, out)                                         // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.Regexpf(t, rxRegexpStructAlias, out, "msg with args %d %s", 42, "42")       // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexp(t, rxRegexpStructAlias, out)                                      // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexpf(t, rxRegexpStructAlias, out, "msg with args %d %s", 42, "42")    // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.Regexp(t, 42, out)                                                          // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.Regexpf(t, 42, out, "msg with args %d %s", 42, "42")                        // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexp(t, 42, out)                                                       // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexpf(t, 42, out, "msg with args %d %s", 42, "42")                     // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.Regexp(t, int8(42), out)                                                    // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.Regexpf(t, int8(42), out, "msg with args %d %s", 42, "42")                  // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexp(t, int8(42), out)                                                 // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexpf(t, int8(42), out, "msg with args %d %s", 42, "42")               // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.Regexp(t, uint8(42), out)                                                   // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.Regexpf(t, uint8(42), out, "msg with args %d %s", 42, "42")                 // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexp(t, uint8(42), out)                                                // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexpf(t, uint8(42), out, "msg with args %d %s", 42, "42")              // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.Regexp(t, 42.0, out)                                                        // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.Regexpf(t, 42.0, out, "msg with args %d %s", 42, "42")                      // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexp(t, 42.0, out)                                                     // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexpf(t, 42.0, out, "msg with args %d %s", 42, "42")                   // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.Regexp(t, testStringer{}, out)                                              // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.Regexpf(t, testStringer{}, out, "msg with args %d %s", 42, "42")            // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexp(t, testStringer{}, out)                                           // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
+		assert.NotRegexpf(t, testStringer{}, out, "msg with args %d %s", 42, "42")         // want "regexp: use string or \\*regexp\\.Regexp as the first argument"
 	}
 
 	// Valid.
@@ -26,5 +85,17 @@ func TestRegexpChecker(t *testing.T) {
 		assert.Regexpf(t, `\[.*\] DEBUG \(.*TestNew.*\): message`, out, "msg with args %d %s", 42, "42")
 		assert.NotRegexp(t, `\[.*\] TRACE message`, out)
 		assert.NotRegexpf(t, `\[.*\] TRACE message`, out, "msg with args %d %s", 42, "42")
+		assert.Regexp(t, myStrAlias(`\w+`), out)
+		assert.Regexpf(t, myStrAlias(`\w+`), out, "msg with args %d %s", 42, "42")
+		assert.NotRegexp(t, myStrAlias(`\w+`), out)
+		assert.NotRegexpf(t, myStrAlias(`\w+`), out, "msg with args %d %s", 42, "42")
+		assert.Regexp(t, compiledRegexp, out)
+		assert.Regexpf(t, compiledRegexp, out, "msg with args %d %s", 42, "42")
+		assert.NotRegexp(t, compiledRegexp, out)
+		assert.NotRegexpf(t, compiledRegexp, out, "msg with args %d %s", 42, "42")
+		assert.Regexp(t, rxAlias, out)
+		assert.Regexpf(t, rxAlias, out, "msg with args %d %s", 42, "42")
+		assert.NotRegexp(t, rxAlias, out)
+		assert.NotRegexpf(t, rxAlias, out, "msg with args %d %s", 42, "42")
 	}
 }

--- a/internal/checkers/regexp.go
+++ b/internal/checkers/regexp.go
@@ -2,6 +2,7 @@ package checkers
 
 import (
 	"go/ast"
+	"go/types"
 
 	"golang.org/x/tools/go/analysis"
 )
@@ -15,6 +16,14 @@ import (
 //
 //	assert.Regexp(t, `\[.*\] DEBUG \(.*TestNew.*\): message`, out)
 //	assert.NotRegexp(t, `\[.*\] TRACE message`, out)
+//
+// Also detects situations like
+//
+//	assert.Regexp(t, []byte(`\w+`), str)
+//
+// and requires
+//
+//	assert.Regexp(t, `\w+`, str) // or *regexp.Regexp
 type Regexp struct{}
 
 // NewRegexp constructs Regexp checker.
@@ -32,13 +41,50 @@ func (checker Regexp) Check(pass *analysis.Pass, call *CallMeta) *analysis.Diagn
 		return nil
 	}
 
-	ce, ok := call.Args[0].(*ast.CallExpr)
-	if !ok || len(ce.Args) != 1 {
-		return nil
-	}
+	arg := call.Args[0]
 
-	if isRegexpMustCompileCall(pass, ce) {
+	ce, ok := arg.(*ast.CallExpr)
+	if ok && len(ce.Args) == 1 && isRegexpMustCompileCall(pass, ce) {
 		return newRemoveMustCompileDiagnostic(pass, checker.Name(), call, ce, ce.Args[0])
 	}
+
+	if !isStringOrRegexpType(pass, arg) {
+		return newDiagnostic(checker.Name(), call,
+			"use string or *regexp.Regexp as the first argument")
+	}
 	return nil
+}
+
+// isStringOrRegexpType returns true if the expression is of a type whose underlying type is string
+// (including untyped strings, defined string types, and string-based type aliases), *regexp.Regexp
+// type (including type aliases), or a type parameter (accepted conservatively to avoid false
+// positives in generic code).
+func isStringOrRegexpType(pass *analysis.Pass, e ast.Expr) bool {
+	t := pass.TypesInfo.TypeOf(e)
+	if t == nil {
+		return false
+	}
+
+	// Conservatively accept type parameters to avoid false positives in generic code.
+	if _, ok := types.Unalias(t).(*types.TypeParam); ok {
+		return true
+	}
+
+	// Check for string types (includes string, untyped string, and string-underlying type aliases).
+	if isUnderlying(pass, e, types.IsString) {
+		return true
+	}
+
+	// Check for *regexp.Regexp (using Unalias on both the type and pointer element to handle
+	// type aliases such as `type MyRx = *regexp.Regexp` or `type MyRegexp = regexp.Regexp`).
+	ptr, ok := types.Unalias(t).(*types.Pointer)
+	if !ok {
+		return false
+	}
+	named, ok := types.Unalias(ptr.Elem()).(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	return obj.Pkg() != nil && obj.Pkg().Path() == "regexp" && obj.Name() == "Regexp"
 }

--- a/internal/checkers/regexp.go
+++ b/internal/checkers/regexp.go
@@ -2,6 +2,7 @@ package checkers
 
 import (
 	"go/ast"
+	"go/types"
 
 	"golang.org/x/tools/go/analysis"
 )
@@ -15,6 +16,14 @@ import (
 //
 //	assert.Regexp(t, `\[.*\] DEBUG \(.*TestNew.*\): message`, out)
 //	assert.NotRegexp(t, `\[.*\] TRACE message`, out)
+//
+// Also detects situations like
+//
+//	assert.Regexp(t, []byte(`\w+`), str)
+//
+// and requires
+//
+//	assert.Regexp(t, `\w+`, str) // or *regexp.Regexp
 type Regexp struct{}
 
 // NewRegexp constructs Regexp checker.
@@ -32,13 +41,55 @@ func (checker Regexp) Check(pass *analysis.Pass, call *CallMeta) *analysis.Diagn
 		return nil
 	}
 
-	ce, ok := call.Args[0].(*ast.CallExpr)
-	if !ok || len(ce.Args) != 1 {
-		return nil
-	}
+	arg := call.Args[0]
 
-	if isRegexpMustCompileCall(pass, ce) {
+	ce, ok := arg.(*ast.CallExpr)
+	if ok && len(ce.Args) == 1 && isRegexpMustCompileCall(pass, ce) {
 		return newRemoveMustCompileDiagnostic(pass, checker.Name(), call, ce, ce.Args[0])
 	}
+
+	if !isStringOrRegexpType(pass, arg) {
+		return newDiagnostic(checker.Name(), call,
+			"use string or *regexp.Regexp as the first argument")
+	}
 	return nil
+}
+
+// isStringOrRegexpType returns true if the expression is of strict string type
+// (including untyped strings and aliases to string), *regexp.Regexp (including aliases to
+// *regexp.Regexp), or a type parameter accepted conservatively to avoid false positives for code
+// like `func[T interface{ ~string }](rx T) { assert.Regexp(t, rx, str) }`.
+//
+// Note that *types.TypeParam and *types.Alias are different cases and are handled separately.
+func isStringOrRegexpType(pass *analysis.Pass, e ast.Expr) bool {
+	t := pass.TypesInfo.TypeOf(e)
+	if t == nil {
+		return false
+	}
+
+	unaliased := types.Unalias(t)
+
+	// Conservatively accept type parameters to avoid false positives for code like
+	// `func[T interface{ ~string }](rx T) { assert.Regexp(t, rx, str) }`.
+	if _, ok := unaliased.(*types.TypeParam); ok {
+		return true
+	}
+
+	// Accept only strict string and untyped string, plus aliases to those exact types.
+	basic, ok := unaliased.(*types.Basic)
+	if ok && (basic.Kind() == types.String || basic.Kind() == types.UntypedString) {
+		return true
+	}
+
+	// Accept *regexp.Regexp and aliases to that exact pointer type.
+	ptr, ok := unaliased.(*types.Pointer)
+	if !ok {
+		return false
+	}
+	named, ok := ptr.Elem().(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	return obj.Pkg() != nil && obj.Pkg().Path() == "regexp" && obj.Name() == "Regexp"
 }

--- a/internal/testgen/gen_regexp.go
+++ b/internal/testgen/gen_regexp.go
@@ -15,30 +15,119 @@ func (RegexpTestsGenerator) Checker() checkers.Checker {
 
 func (g RegexpTestsGenerator) TemplateData() any {
 	var (
-		checker = g.Checker().Name()
-		report  = checker + ": remove unnecessary regexp.MustCompile"
+		checker           = g.Checker().Name()
+		reportMustCompile = checker + ": remove unnecessary regexp.MustCompile"
+		reportInvalidArg  = checker + ": use string or *regexp.Regexp as the first argument"
 	)
 
 	return struct {
-		CheckerName       CheckerName
-		InvalidAssertions []Assertion
-		ValidAssertions   []Assertion
+		CheckerName           CheckerName
+		InvalidMustCompile    []Assertion
+		InvalidTypeAssertions []Assertion
+		ValidAssertions       []Assertion
 	}{
 		CheckerName: CheckerName(checker),
-		InvalidAssertions: []Assertion{
+		InvalidMustCompile: []Assertion{
 			{
 				Fn: "Regexp", Argsf: "regexp.MustCompile(`\\[.*\\] DEBUG \\(.*TestNew.*\\): message`), out",
-				ReportMsgf: report, ProposedArgsf: "`\\[.*\\] DEBUG \\(.*TestNew.*\\): message`, out",
+				ReportMsgf: reportMustCompile, ProposedArgsf: "`\\[.*\\] DEBUG \\(.*TestNew.*\\): message`, out",
 			},
-
 			{
 				Fn: "NotRegexp", Argsf: "regexp.MustCompile(`\\[.*\\] TRACE message`), out",
-				ReportMsgf: report, ProposedArgsf: "`\\[.*\\] TRACE message`, out",
+				ReportMsgf: reportMustCompile, ProposedArgsf: "`\\[.*\\] TRACE message`, out",
+			},
+		},
+		InvalidTypeAssertions: []Assertion{
+			{
+				Fn:         "Regexp",
+				Argsf:      "[]byte(`\\w+`), out",
+				ReportMsgf: reportInvalidArg,
+			},
+			{
+				Fn:         "NotRegexp",
+				Argsf:      "[]byte(`\\w+`), out",
+				ReportMsgf: reportInvalidArg,
+			},
+			{
+				Fn:         "Regexp",
+				Argsf:      "myDefinedString(`\\w+`), out",
+				ReportMsgf: reportInvalidArg,
+			},
+			{
+				Fn:         "NotRegexp",
+				Argsf:      "myDefinedString(`\\w+`), out",
+				ReportMsgf: reportInvalidArg,
+			},
+			{
+				Fn:         "Regexp",
+				Argsf:      "rxRegexpStructAlias, out",
+				ReportMsgf: reportInvalidArg,
+			},
+			{
+				Fn:         "NotRegexp",
+				Argsf:      "rxRegexpStructAlias, out",
+				ReportMsgf: reportInvalidArg,
+			},
+			{
+				Fn:         "Regexp",
+				Argsf:      "42, out",
+				ReportMsgf: reportInvalidArg,
+			},
+			{
+				Fn:         "NotRegexp",
+				Argsf:      "42, out",
+				ReportMsgf: reportInvalidArg,
+			},
+			{
+				Fn:         "Regexp",
+				Argsf:      "int8(42), out",
+				ReportMsgf: reportInvalidArg,
+			},
+			{
+				Fn:         "NotRegexp",
+				Argsf:      "int8(42), out",
+				ReportMsgf: reportInvalidArg,
+			},
+			{
+				Fn:         "Regexp",
+				Argsf:      "uint8(42), out",
+				ReportMsgf: reportInvalidArg,
+			},
+			{
+				Fn:         "NotRegexp",
+				Argsf:      "uint8(42), out",
+				ReportMsgf: reportInvalidArg,
+			},
+			{
+				Fn:         "Regexp",
+				Argsf:      "42.0, out",
+				ReportMsgf: reportInvalidArg,
+			},
+			{
+				Fn:         "NotRegexp",
+				Argsf:      "42.0, out",
+				ReportMsgf: reportInvalidArg,
+			},
+			{
+				Fn:         "Regexp",
+				Argsf:      "testStringer{}, out",
+				ReportMsgf: reportInvalidArg,
+			},
+			{
+				Fn:         "NotRegexp",
+				Argsf:      "testStringer{}, out",
+				ReportMsgf: reportInvalidArg,
 			},
 		},
 		ValidAssertions: []Assertion{
 			{Fn: "Regexp", Argsf: "`\\[.*\\] DEBUG \\(.*TestNew.*\\): message`, out"},
 			{Fn: "NotRegexp", Argsf: "`\\[.*\\] TRACE message`, out"},
+			{Fn: "Regexp", Argsf: "myStrAlias(`\\w+`), out"},
+			{Fn: "NotRegexp", Argsf: "myStrAlias(`\\w+`), out"},
+			{Fn: "Regexp", Argsf: "compiledRegexp, out"},
+			{Fn: "NotRegexp", Argsf: "compiledRegexp, out"},
+			{Fn: "Regexp", Argsf: "rxAlias, out"},
+			{Fn: "NotRegexp", Argsf: "rxAlias, out"},
 		},
 	}
 }
@@ -66,12 +155,42 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type myDefinedString string
+
+type myStrAlias = string
+
+type myRegexpStructAlias = regexp.Regexp
+
+type testStringer struct{}
+
+func (testStringer) String() string { return "42" }
+
+// myRxAlias is a type alias for *regexp.Regexp used to verify that alias types are accepted.
+type myRxAlias = *regexp.Regexp
+
+// assertRegexpGeneric demonstrates that a type parameter is accepted conservatively.
+// This differs from aliases such as myStrAlias or myRxAlias, which are handled separately.
+func assertRegexpGeneric[T ~string](t *testing.T, rx T, str string) {
+	assert.Regexp(t, rx, str)
+	assert.NotRegexp(t, rx, str)
+}
+
 func {{ .CheckerName.AsTestName }}(t *testing.T) {
 	var out string
+	compiledRegexp := regexp.MustCompile(` + "`" + `\w+` + "`" + `)
+	var rxRegexpStructAlias *myRegexpStructAlias = regexp.MustCompile(` + "`" + `\w+` + "`" + `)
+	var rxAlias myRxAlias = regexp.MustCompile(` + "`" + `\w+` + "`" + `)
 
-	// Invalid.
+	// Invalid: regexp.MustCompile usage.
 	{
-		{{- range $ai, $assrn := $.InvalidAssertions }}
+		{{- range $ai, $assrn := $.InvalidMustCompile }}
+			{{ NewAssertionExpander.Expand $assrn "assert" "t" nil }}
+		{{- end }}
+	}
+
+	// Invalid: non-string, non-*regexp.Regexp first argument.
+	{
+		{{- range $ai, $assrn := $.InvalidTypeAssertions }}
 			{{ NewAssertionExpander.Expand $assrn "assert" "t" nil }}
 		{{- end }}
 	}

--- a/internal/testgen/gen_regexp.go
+++ b/internal/testgen/gen_regexp.go
@@ -15,30 +15,47 @@ func (RegexpTestsGenerator) Checker() checkers.Checker {
 
 func (g RegexpTestsGenerator) TemplateData() any {
 	var (
-		checker = g.Checker().Name()
-		report  = checker + ": remove unnecessary regexp.MustCompile"
+		checker           = g.Checker().Name()
+		reportMustCompile = checker + ": remove unnecessary regexp.MustCompile"
+		reportInvalidArg  = checker + ": use string or *regexp.Regexp as the first argument"
 	)
 
 	return struct {
-		CheckerName       CheckerName
-		InvalidAssertions []Assertion
-		ValidAssertions   []Assertion
+		CheckerName           CheckerName
+		InvalidMustCompile    []Assertion
+		InvalidTypeAssertions []Assertion
+		ValidAssertions       []Assertion
 	}{
 		CheckerName: CheckerName(checker),
-		InvalidAssertions: []Assertion{
+		InvalidMustCompile: []Assertion{
 			{
 				Fn: "Regexp", Argsf: "regexp.MustCompile(`\\[.*\\] DEBUG \\(.*TestNew.*\\): message`), out",
-				ReportMsgf: report, ProposedArgsf: "`\\[.*\\] DEBUG \\(.*TestNew.*\\): message`, out",
+				ReportMsgf: reportMustCompile, ProposedArgsf: "`\\[.*\\] DEBUG \\(.*TestNew.*\\): message`, out",
 			},
-
 			{
 				Fn: "NotRegexp", Argsf: "regexp.MustCompile(`\\[.*\\] TRACE message`), out",
-				ReportMsgf: report, ProposedArgsf: "`\\[.*\\] TRACE message`, out",
+				ReportMsgf: reportMustCompile, ProposedArgsf: "`\\[.*\\] TRACE message`, out",
+			},
+		},
+		InvalidTypeAssertions: []Assertion{
+			{
+				Fn:         "Regexp",
+				Argsf:      "[]byte(`\\w+`), out",
+				ReportMsgf: reportInvalidArg,
+			},
+			{
+				Fn:         "NotRegexp",
+				Argsf:      "[]byte(`\\w+`), out",
+				ReportMsgf: reportInvalidArg,
 			},
 		},
 		ValidAssertions: []Assertion{
 			{Fn: "Regexp", Argsf: "`\\[.*\\] DEBUG \\(.*TestNew.*\\): message`, out"},
 			{Fn: "NotRegexp", Argsf: "`\\[.*\\] TRACE message`, out"},
+			{Fn: "Regexp", Argsf: "compiledRegexp, out"},
+			{Fn: "NotRegexp", Argsf: "compiledRegexp, out"},
+			{Fn: "Regexp", Argsf: "rxAlias, out"},
+			{Fn: "NotRegexp", Argsf: "rxAlias, out"},
 		},
 	}
 }
@@ -66,12 +83,30 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// myRxAlias is a type alias for *regexp.Regexp used to verify that alias types are accepted.
+type myRxAlias = *regexp.Regexp
+
+// assertRegexpGeneric demonstrates that type parameters are accepted conservatively.
+func assertRegexpGeneric[T ~string](t *testing.T, rx T, str string) {
+	assert.Regexp(t, rx, str)
+	assert.NotRegexp(t, rx, str)
+}
+
 func {{ .CheckerName.AsTestName }}(t *testing.T) {
 	var out string
+	compiledRegexp := regexp.MustCompile(` + "`" + `\w+` + "`" + `)
+	var rxAlias myRxAlias = regexp.MustCompile(` + "`" + `\w+` + "`" + `)
 
-	// Invalid.
+	// Invalid: regexp.MustCompile usage.
 	{
-		{{- range $ai, $assrn := $.InvalidAssertions }}
+		{{- range $ai, $assrn := $.InvalidMustCompile }}
+			{{ NewAssertionExpander.Expand $assrn "assert" "t" nil }}
+		{{- end }}
+	}
+
+	// Invalid: non-string, non-*regexp.Regexp first argument.
+	{
+		{{- range $ai, $assrn := $.InvalidTypeAssertions }}
 			{{ NewAssertionExpander.Expand $assrn "assert" "t" nil }}
 		{{- end }}
 	}


### PR DESCRIPTION
`assert.Regexp`/`assert.NotRegexp` accept `rx interface{}`, but testify's `matchRegexp` only handles `*regexp.Regexp` and `string` correctly — anything else silently goes through `regexp.MustCompile(fmt.Sprint(rx))`, which produces unexpected results (e.g. `[]byte("pattern")` compiles to its decimal byte representation).

## Changes

- **`internal/checkers/regexp.go`**: Extended `Check()` to emit `"use string or *regexp.Regexp as the first argument"` when `rx` is neither a string type (typed, untyped, or string-underlying alias) nor `*regexp.Regexp`. Added `isStringOrRegexpType` helper.
- **`internal/testgen/gen_regexp.go`**: Added invalid test cases (`[]byte` arg) and valid test cases (pre-compiled `*regexp.Regexp` variable); updated template to declare `compiledRegexp`.

```go
// Now flagged:
assert.Regexp(t, []byte(`\w+`), output) // regexp: use string or *regexp.Regexp as the first argument

// Valid — no warning:
assert.Regexp(t, `\w+`, output)
assert.Regexp(t, compiledRegexp, output)
```

Closes #81