### PR TITLE
Fix false positives on `collect.Errorf` calls in `require-error` checker

### DIFF
--- a/analyzer/testdata/src/require-error-skip-logic/issue287_test.go
+++ b/analyzer/testdata/src/require-error-skip-logic/issue287_test.go
@@ -1,0 +1,20 @@
+package requireerrorskiplogic
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type checkerIssue287 struct {
+	foo  []any
+	bar  []any
+	name string
+}
+
+// collect.Errorf is not a testify assertion; it should not be reported.
+func (c *checkerIssue287) cond(collect *assert.CollectT) {
+	if c.foo == nil && c.bar == nil {
+		collect.Errorf("precondition not satisfied")
+	}
+	require.NotEmpty(collect, c.name)
+}

--- a/internal/checkers/require_error.go
+++ b/internal/checkers/require_error.go
@@ -2,10 +2,14 @@ package checkers
 
 import (
 	"go/ast"
+	"go/types"
 	"regexp"
 
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/ast/inspector"
+
+	"github.com/Antonboom/testifylint/internal/analysisutil"
+	"github.com/Antonboom/testifylint/internal/testify"
 )
 
 const requireErrorReport = "for error assertions use require"
@@ -124,6 +128,13 @@ func (checker RequireError) Check(pass *analysis.Pass, insp *inspector.Inspector
 			default:
 				continue
 			case "Error", "ErrorIs", "ErrorAs", "EqualError", "ErrorContains", "NoError", "NotErrorIs":
+			}
+
+			// For non-package (method) calls, verify the method is defined on
+			// *assert.Assertions or *require.Assertions, not on other types like
+			// *assert.CollectT which implements testing.T but is not an assertion object.
+			if !c.testifyCall.IsPkg && !isAssertionsReceiverMethod(c.testifyCall) {
+				continue
 			}
 
 			if needToSkipBasedOnContext(c, i, calls, callsByBlock) {
@@ -246,4 +257,26 @@ type callMeta struct {
 
 func isNoErrorAssertion(fnName string) bool {
 	return (fnName == "NoError") || (fnName == "NoErrorf")
+}
+
+// isAssertionsReceiverMethod returns true if the method call is defined on *assert.Assertions
+// or *require.Assertions (including promoted methods on suite types), as opposed to other
+// types in those packages such as *assert.CollectT.
+func isAssertionsReceiverMethod(call *CallMeta) bool {
+	sig := call.Fn.Signature
+	recv := sig.Recv()
+	if recv == nil {
+		return false
+	}
+	recvType := recv.Type()
+	if ptr, isPtr := recvType.(*types.Pointer); isPtr {
+		recvType = ptr.Elem()
+	}
+	named, isNamed := recvType.(*types.Named)
+	if !isNamed || named.Obj().Name() != "Assertions" {
+		return false
+	}
+	pkg := named.Obj().Pkg()
+	return analysisutil.IsPkg(pkg, testify.AssertPkgName, testify.AssertPkgPath) ||
+		analysisutil.IsPkg(pkg, testify.RequirePkgName, testify.RequirePkgPath)
 }


### PR DESCRIPTION
`*assert.CollectT` implements `testing.T` via its `Errorf(format string, args ...interface{})` method. The `require-error` checker was incorrectly matching this against the `Error`/`Errorf` assertion pattern, producing a false positive whenever another testify call appeared in the same scope.

## Changes

- **`internal/checkers/require_error.go`**: For non-package (method) calls, guard with `isAssertionsReceiverMethod` — a new helper that inspects the method's declared receiver type (name + package path) to confirm it is `*assert.Assertions` or `*require.Assertions`, not an incidental type like `*assert.CollectT`.
- **`analyzer/testdata/src/require-error-skip-logic/issue287_test.go`**: Regression test reproducing the exact scenario — `collect.Errorf` must not be flagged when paired with other testify calls in the same function.

## Example

```go
func (c *checker) cond(collect *assert.CollectT) {
    if c.foo == nil && c.bar == nil {
        collect.Errorf("precondition not satisfied") // no longer a false positive
    }
    require.NotEmpty(collect, c.name)
}
```

The `formatter` checker, which legitimately inspects `collect.Errorf` for format-string correctness, is unaffected.

Closes #287 