### PR TITLE
Add ErrorContains checker

### DIFF
--- a/analyzer/testdata/src/checkers-default/contains/contains_test.go
+++ b/analyzer/testdata/src/checkers-default/contains/contains_test.go
@@ -59,6 +59,8 @@ func TestContainsChecker(t *testing.T) {
 		assert.NotContains(t, log, "params", map[string]interface{}{"query": "test statement"}, "msg")                           // want "contains: invalid usage of assert\\.NotContains, use assert\\.NotSubset for multi elements assertion"
 		assert.NotContains(t, log, "params", map[string]interface{}{"query": "test statement"}, "msg with arg %d", 42)           // want "contains: invalid usage of assert\\.NotContains, use assert\\.NotSubset for multi elements assertion"
 		assert.NotContains(t, log, "params", map[string]interface{}{"query": "test statement"}, "msg with args %d %s", 42, "42") // want "contains: invalid usage of assert\\.NotContains, use assert\\.NotSubset for multi elements assertion"
+		assert.Contains(t, errSentinel.Error(), "user")                                                                          // want "contains: use assert\\.ErrorContains"
+		assert.Containsf(t, errSentinel.Error(), "user", "msg with args %d %s", 42, "42")                                        // want "contains: use assert\\.ErrorContainsf"
 	}
 
 	// Valid.
@@ -75,8 +77,6 @@ func TestContainsChecker(t *testing.T) {
 
 	// Ignored.
 	{
-		assert.Contains(t, errSentinel.Error(), "user")
-		assert.Containsf(t, errSentinel.Error(), "user", "msg with args %d %s", 42, "42")
 		assert.NotContains(t, errSentinel.Error(), "user")
 		assert.NotContainsf(t, errSentinel.Error(), "user", "msg with args %d %s", 42, "42")
 		assert.Contains(t, string(b), "MASKED_KEY=[MASKED]")

--- a/analyzer/testdata/src/checkers-default/contains/contains_test.go
+++ b/analyzer/testdata/src/checkers-default/contains/contains_test.go
@@ -23,6 +23,7 @@ func TestContainsChecker(t *testing.T) {
 		errSentinel = errors.New("user not found")
 		metrics     = []metric{}
 		log         = []string{}
+		msgArgs     []any
 	)
 
 	// Invalid.
@@ -60,7 +61,7 @@ func TestContainsChecker(t *testing.T) {
 		assert.NotContains(t, log, "params", map[string]interface{}{"query": "test statement"}, "msg with arg %d", 42)           // want "contains: invalid usage of assert\\.NotContains, use assert\\.NotSubset for multi elements assertion"
 		assert.NotContains(t, log, "params", map[string]interface{}{"query": "test statement"}, "msg with args %d %s", 42, "42") // want "contains: invalid usage of assert\\.NotContains, use assert\\.NotSubset for multi elements assertion"
 		assert.Contains(t, errSentinel.Error(), "user")                                                                          // want "contains: use assert\\.ErrorContains"
-		assert.Containsf(t, errSentinel.Error(), "user", "msg with args %d %s", 42, "42")                                        // want "contains: use assert\\.ErrorContainsf"
+		assert.Contains(t, errSentinel.Error(), "user", msgArgs...)                                                              // want "contains: use assert\\.ErrorContains"
 	}
 
 	// Valid.
@@ -99,12 +100,5 @@ func TestContainsChecker(t *testing.T) {
 		assert.Falsef(t, bytes.Contains(b, []byte("a")), "msg with args %d %s", 42, "42")
 		assert.True(t, !bytes.Contains(b, []byte("a")))
 		assert.Truef(t, !bytes.Contains(b, []byte("a")), "msg with args %d %s", 42, "42")
-	}
-}
-
-// ErrorContains returns an assertion to check if the error contains the given string.
-func ErrorContains(contains string) assert.ErrorAssertionFunc {
-	return func(t assert.TestingT, err error, msgAndArgs ...interface{}) bool {
-		return assert.Contains(t, err.Error(), contains, msgAndArgs...)
 	}
 }

--- a/analyzer/testdata/src/checkers-default/contains/contains_test.go.golden
+++ b/analyzer/testdata/src/checkers-default/contains/contains_test.go.golden
@@ -59,6 +59,8 @@ func TestContainsChecker(t *testing.T) {
 		assert.NotContains(t, log, "params", map[string]interface{}{"query": "test statement"}, "msg")                           // want "contains: invalid usage of assert\\.NotContains, use assert\\.NotSubset for multi elements assertion"
 		assert.NotContains(t, log, "params", map[string]interface{}{"query": "test statement"}, "msg with arg %d", 42)           // want "contains: invalid usage of assert\\.NotContains, use assert\\.NotSubset for multi elements assertion"
 		assert.NotContains(t, log, "params", map[string]interface{}{"query": "test statement"}, "msg with args %d %s", 42, "42") // want "contains: invalid usage of assert\\.NotContains, use assert\\.NotSubset for multi elements assertion"
+		assert.ErrorContains(t, errSentinel, "user")                                                                             // want "contains: use assert\\.ErrorContains"
+		assert.ErrorContainsf(t, errSentinel, "user", "msg with args %d %s", 42, "42")                                           // want "contains: use assert\\.ErrorContainsf"
 	}
 
 	// Valid.
@@ -75,8 +77,6 @@ func TestContainsChecker(t *testing.T) {
 
 	// Ignored.
 	{
-		assert.Contains(t, errSentinel.Error(), "user")
-		assert.Containsf(t, errSentinel.Error(), "user", "msg with args %d %s", 42, "42")
 		assert.NotContains(t, errSentinel.Error(), "user")
 		assert.NotContainsf(t, errSentinel.Error(), "user", "msg with args %d %s", 42, "42")
 		assert.Contains(t, string(b), "MASKED_KEY=[MASKED]")

--- a/analyzer/testdata/src/checkers-default/contains/contains_test.go.golden
+++ b/analyzer/testdata/src/checkers-default/contains/contains_test.go.golden
@@ -23,6 +23,7 @@ func TestContainsChecker(t *testing.T) {
 		errSentinel = errors.New("user not found")
 		metrics     = []metric{}
 		log         = []string{}
+		msgArgs     []any
 	)
 
 	// Invalid.
@@ -60,7 +61,7 @@ func TestContainsChecker(t *testing.T) {
 		assert.NotContains(t, log, "params", map[string]interface{}{"query": "test statement"}, "msg with arg %d", 42)           // want "contains: invalid usage of assert\\.NotContains, use assert\\.NotSubset for multi elements assertion"
 		assert.NotContains(t, log, "params", map[string]interface{}{"query": "test statement"}, "msg with args %d %s", 42, "42") // want "contains: invalid usage of assert\\.NotContains, use assert\\.NotSubset for multi elements assertion"
 		assert.ErrorContains(t, errSentinel, "user")                                                                             // want "contains: use assert\\.ErrorContains"
-		assert.ErrorContainsf(t, errSentinel, "user", "msg with args %d %s", 42, "42")                                           // want "contains: use assert\\.ErrorContainsf"
+		assert.ErrorContains(t, errSentinel, "user", msgArgs...)                                                                 // want "contains: use assert\\.ErrorContains"
 	}
 
 	// Valid.
@@ -99,12 +100,5 @@ func TestContainsChecker(t *testing.T) {
 		assert.Falsef(t, bytes.Contains(b, []byte("a")), "msg with args %d %s", 42, "42")
 		assert.True(t, !bytes.Contains(b, []byte("a")))
 		assert.Truef(t, !bytes.Contains(b, []byte("a")), "msg with args %d %s", 42, "42")
-	}
-}
-
-// ErrorContains returns an assertion to check if the error contains the given string.
-func ErrorContains(contains string) assert.ErrorAssertionFunc {
-	return func(t assert.TestingT, err error, msgAndArgs ...interface{}) bool {
-		return assert.Contains(t, err.Error(), contains, msgAndArgs...)
 	}
 }

--- a/internal/checkers/contains.go
+++ b/internal/checkers/contains.go
@@ -15,6 +15,7 @@ import (
 //	assert.True(t, !strings.Contains(a, "abc123"))
 //	assert.Contains(t, arr, 1, 2)
 //	assert.NotContains(t, arr, 1, 2)
+//	assert.Contains(t, err.Error(), "not found")
 //
 // and requires
 //
@@ -22,6 +23,7 @@ import (
 //	assert.NotContains(t, a, "abc123")
 //	assert.Subset(t, arr, 1, 2)
 //	assert.NotSubset(t, arr, 1, 2)
+//	assert.ErrorContains(t, err, "not found")
 type Contains struct{}
 
 // NewContains constructs Contains checker.
@@ -30,6 +32,9 @@ func (Contains) Name() string { return "contains" }
 
 func (checker Contains) Check(pass *analysis.Pass, call *CallMeta) *analysis.Diagnostic {
 	if d := checker.checkStringContains(pass, call); d != nil {
+		return d
+	}
+	if d := checker.checkErrorContains(pass, call); d != nil {
 		return d
 	}
 
@@ -79,6 +84,40 @@ func (checker Contains) checkStringContains(pass *analysis.Pass, call *CallMeta)
 			Pos:     call.Args[0].Pos(),
 			End:     call.Args[0].End(),
 			NewText: formatAsCallArgs(pass, ce.Args[0], ce.Args[1]),
+		})
+}
+
+// checkErrorContains rewrites `assert.Contains(t, err.Error(), substr)` to
+// `assert.ErrorContains(t, err, substr)`. No `NotErrorContains` exists in
+// testify, so the negative form is left alone.
+func (checker Contains) checkErrorContains(pass *analysis.Pass, call *CallMeta) *analysis.Diagnostic {
+	if call.Fn.NameFTrimmed != "Contains" {
+		return nil
+	}
+	if call.Call.Ellipsis.IsValid() {
+		return nil
+	}
+	if len(call.Args) < 2 {
+		return nil
+	}
+
+	errExprCall, ok := call.Args[0].(*ast.CallExpr)
+	if !ok || len(errExprCall.Args) != 0 {
+		return nil
+	}
+	se, ok := errExprCall.Fun.(*ast.SelectorExpr)
+	if !ok || se.Sel.Name != "Error" {
+		return nil
+	}
+	if !isError(pass, se.X) {
+		return nil
+	}
+
+	return newUseFunctionDiagnostic(checker.Name(), call, "ErrorContains",
+		analysis.TextEdit{
+			Pos:     call.Args[0].Pos(),
+			End:     call.Args[0].End(),
+			NewText: formatAsCallArgs(pass, se.X),
 		})
 }
 

--- a/internal/checkers/contains.go
+++ b/internal/checkers/contains.go
@@ -94,9 +94,6 @@ func (checker Contains) checkErrorContains(pass *analysis.Pass, call *CallMeta) 
 	if call.Fn.NameFTrimmed != "Contains" {
 		return nil
 	}
-	if call.Call.Ellipsis.IsValid() {
-		return nil
-	}
 	if len(call.Args) < 2 {
 		return nil
 	}

--- a/internal/testgen/gen_contains.go
+++ b/internal/testgen/gen_contains.go
@@ -98,6 +98,13 @@ func (g ContainsTestsGenerator) TemplateData() any {
 				ProposedFn:    "ErrorContains",
 				ProposedArgsf: `errSentinel, "user"`,
 			},
+			{
+				Fn:            "Contains",
+				Argsf:         `errSentinel.Error(), "user", msgArgs...`,
+				ReportMsgf:    report,
+				ProposedFn:    "ErrorContains",
+				ProposedArgsf: `errSentinel, "user", msgArgs...`,
+			},
 		},
 		IgnoredAssertions: []Assertion{
 			// NotErrorContains does not exist in testify, so we leave NotContains(err.Error(), ...) alone.
@@ -156,6 +163,7 @@ func {{ .CheckerName.AsTestName }}(t *testing.T) {
         errSentinel = errors.New("user not found")
 		metrics     = []metric{}
 		log         = []string{}
+		msgArgs     []any
     )
 
     // Invalid.
@@ -171,7 +179,7 @@ func {{ .CheckerName.AsTestName }}(t *testing.T) {
         {{- end }}
 
         {{- range $ai, $assrn := $.InvalidErrorContainsCases }}
-            {{ NewAssertionExpander.Expand $assrn "assert" "t" nil }}
+            {{ NewAssertionExpander.NotFmtSingleMode.Expand $assrn "assert" "t" nil }}
         {{- end }}
     }
 
@@ -188,12 +196,5 @@ func {{ .CheckerName.AsTestName }}(t *testing.T) {
             {{ NewAssertionExpander.Expand $assrn "assert" "t" nil }}
         {{- end }}
     }
-}
-
-// ErrorContains returns an assertion to check if the error contains the given string.
-func ErrorContains(contains string) assert.ErrorAssertionFunc {
-	return func(t assert.TestingT, err error, msgAndArgs ...interface{}) bool {
-		return assert.Contains(t, err.Error(), contains, msgAndArgs...)
-	}
 }
 `

--- a/internal/testgen/gen_contains.go
+++ b/internal/testgen/gen_contains.go
@@ -20,12 +20,13 @@ func (g ContainsTestsGenerator) TemplateData() any {
 	)
 
 	return struct {
-		CheckerName        CheckerName
-		Vars               []string
-		InvalidAssertions  []Assertion
-		InvalidSubsetCases []Assertion
-		ValidAssertions    []Assertion
-		IgnoredAssertions  []Assertion
+		CheckerName               CheckerName
+		Vars                      []string
+		InvalidAssertions         []Assertion
+		InvalidSubsetCases        []Assertion
+		InvalidErrorContainsCases []Assertion
+		ValidAssertions           []Assertion
+		IgnoredAssertions         []Assertion
 	}{
 		CheckerName: CheckerName(checker),
 		Vars:        []string{"s", "string(b)"},
@@ -89,9 +90,18 @@ func (g ContainsTestsGenerator) TemplateData() any {
 			{Fn: "Subset", Argsf: `metrics, []metric{{time: 1}, {time: 2}}`},
 			{Fn: "NotSubset", Argsf: `metrics, []metric{{time: 1}, {time: 2}}`},
 		},
+		InvalidErrorContainsCases: []Assertion{
+			{
+				Fn:            "Contains",
+				Argsf:         `errSentinel.Error(), "user"`,
+				ReportMsgf:    report,
+				ProposedFn:    "ErrorContains",
+				ProposedArgsf: `errSentinel, "user"`,
+			},
+		},
 		IgnoredAssertions: []Assertion{
-			{Fn: "Contains", Argsf: `errSentinel.Error(), "user"`},    // error-compare case.
-			{Fn: "NotContains", Argsf: `errSentinel.Error(), "user"`}, // error-compare case.
+			// NotErrorContains does not exist in testify, so we leave NotContains(err.Error(), ...) alone.
+			{Fn: "NotContains", Argsf: `errSentinel.Error(), "user"`},
 
 			{Fn: "Contains", Argsf: `string(b), "MASKED_KEY=[MASKED]"`},
 			{Fn: "Contains", Argsf: `metrics, metrics`},
@@ -158,6 +168,10 @@ func {{ .CheckerName.AsTestName }}(t *testing.T) {
 
         {{- range $ai, $assrn := $.InvalidSubsetCases }}
             {{ NewAssertionExpander.NotFmtSetMode.Expand $assrn "assert" "t" nil }}
+        {{- end }}
+
+        {{- range $ai, $assrn := $.InvalidErrorContainsCases }}
+            {{ NewAssertionExpander.Expand $assrn "assert" "t" nil }}
         {{- end }}
     }
 


### PR DESCRIPTION
Another case of users using `require.Contains(t, err.Error, ...)` instead of the built in testify `require.ErrorContains(t, err, ...)`